### PR TITLE
fix: toolbar window on macos

### DIFF
--- a/src-tauri/src/toolbar/mod.rs
+++ b/src-tauri/src/toolbar/mod.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
-use tauri::{App, AppHandle, Manager, PhysicalSize, Position, Size, WindowBuilder, WindowUrl};
+use tauri::{
+    AppHandle, LogicalSize, Manager, PhysicalSize, Position, Size, WindowBuilder, WindowUrl,
+};
 
 pub fn init_toolbar(app: &AppHandle) {
     println!("toolbar created");
@@ -11,22 +12,43 @@ pub fn init_toolbar(app: &AppHandle) {
         .focused(true)
         .center();
 
-
-    #[cfg(not(target_os = "macos"))]{
+    #[cfg(not(target_os = "macos"))]
+    {
         toolbar_win = toolbar_win.transparent(true);
     }
-    
 
     let toolbar_win = toolbar_win.build().expect("Failed to open toolbar");
 
-    let monitor = toolbar_win.primary_monitor().unwrap().unwrap();
-
-    let size = Size::Physical(PhysicalSize {
-        width: 150,
-        height: 70,
+    let size = Size::Logical(LogicalSize {
+        width: 150.0,
+        height: 70.0,
     });
 
     toolbar_win.set_size(size).unwrap();
+
+    #[cfg(target_os = "macos")]
+    {
+        use cocoa::{appkit::NSColor, base::nil, foundation::NSString};
+        use objc::{class, msg_send, sel, sel_impl};
+
+        toolbar_win
+        .to_owned()
+        .run_on_main_thread(move || unsafe {
+            let id = toolbar_win.ns_window().unwrap() as cocoa::base::id;
+            let color =
+                NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 0.0);
+            let _: cocoa::base::id = msg_send![id, setBackgroundColor: color];
+            toolbar_win.with_webview(|webview| {
+                // !!! has delay
+                let id = webview.inner();
+                let no: cocoa::base::id = msg_send![class!(NSNumber), numberWithBool:0];
+                let _: cocoa::base::id =
+                        msg_send![id, setValue:no forKey: NSString::alloc(nil).init_str("drawsBackground")];
+        })
+        .ok();
+        })
+        .unwrap();
+    }
 }
 
 // create a toggle_toolbar function

--- a/src-tauri/src/toolbar/mod.rs
+++ b/src-tauri/src/toolbar/mod.rs
@@ -1,6 +1,4 @@
-use tauri::{
-    AppHandle, LogicalSize, Manager, PhysicalSize, Position, Size, WindowBuilder, WindowUrl,
-};
+use tauri::{AppHandle, LogicalSize, Manager, Position, Size, WindowBuilder, WindowUrl};
 
 pub fn init_toolbar(app: &AppHandle) {
     println!("toolbar created");

--- a/src-tauri/src/toolbar/mod.rs
+++ b/src-tauri/src/toolbar/mod.rs
@@ -1,7 +1,6 @@
 use tauri::{AppHandle, LogicalSize, Manager, Position, Size, WindowBuilder, WindowUrl};
 
 pub fn init_toolbar(app: &AppHandle) {
-    println!("toolbar created");
     let mut toolbar_win = WindowBuilder::new(app, "toolbar", WindowUrl::App("/toolbar".into()))
         .always_on_top(true)
         .decorations(false)
@@ -61,11 +60,10 @@ pub fn toggle_toolbar(app: &AppHandle) {
 
 #[tauri::command]
 pub async fn show_toolbar(button_coords: Vec<u32>, area: Vec<u32>, app: AppHandle) {
-    println!("show_toolbar here!");
     if app.get_window("toolbar").is_none() {
         crate::toolbar::init_toolbar(&app);
     }
-    println!("Coordinates {:?}", button_coords);
+    println!("Toolbar created at {:?}", button_coords);
     let toolbar_win = app.get_window("toolbar").unwrap();
     let pos = Position::Logical((button_coords[0], button_coords[1]).into());
     toolbar_win.set_position(pos).unwrap();
@@ -76,7 +74,6 @@ pub async fn show_toolbar(button_coords: Vec<u32>, area: Vec<u32>, app: AppHandl
 
 #[tauri::command]
 pub async fn hide_toolbar(app: AppHandle) {
-    println!("hide_toolbar here!");
     let toolbar_win = app.get_window("toolbar").unwrap();
     toolbar_win.hide().unwrap();
 }


### PR DESCRIPTION
Changes made:
1. transparency on macOS needs to handled my making ray objc calls
2. `LogicalPosition` and `LogicalSize` are used to create the window
3. removes extra code from the file