### PR TITLE
feat: adds auto-update feature

### DIFF
--- a/src-tauri/src/toolbar/mod.rs
+++ b/src-tauri/src/toolbar/mod.rs
@@ -79,6 +79,7 @@ pub async fn show_toolbar(button_coords: Vec<u32>, area: Vec<u32>, app: AppHandl
 
 #[tauri::command]
 pub async fn hide_toolbar(app: AppHandle) {
-    let toolbar_win = app.get_webview_window("toolbar").unwrap();
-    toolbar_win.hide().unwrap();
+    if let Some(window) = app.get_webview_window("toolbar") {
+        window.hide().expect("Failed to hide toolbar");
+    }
 }

--- a/src-tauri/src/toolbar/mod.rs
+++ b/src-tauri/src/toolbar/mod.rs
@@ -51,15 +51,6 @@ pub fn init_toolbar(app: &AppHandle) {
     }
 }
 
-pub fn toggle_toolbar(app: &AppHandle) {
-    let toolbar_win = app.get_webview_window("toolbar").unwrap();
-    if toolbar_win.is_visible().unwrap() {
-        toolbar_win.hide().unwrap();
-    } else {
-        toolbar_win.show().unwrap();
-    }
-}
-
 #[tauri::command]
 pub async fn show_toolbar(button_coords: Vec<u32>, area: Vec<u32>, app: AppHandle) {
     if app.get_webview_window("toolbar").is_none() {

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -4,12 +4,23 @@ use crate::cropper::toggle_cropper;
 use opener::open;
 use tauri::{
     image::Image,
-    menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem},
+    menu::{AboutMetadataBuilder, MenuBuilder, MenuItemBuilder, PredefinedMenuItem},
     tray::{ClickType, TrayIconBuilder},
     AppHandle,
 };
 
 pub fn build(app: &AppHandle) {
+    let about_metadata = AboutMetadataBuilder::new()
+        .short_version("Alpha".into())
+        .icon(Some(
+            Image::from_bytes(include_bytes!("../../icons/128x128.png")).expect(""),
+        ))
+        .copyright("©2024 Helmer Media Private Limited".into())
+        .website("https://www.helmer.app/micro".into())
+        .website_label("Visit Website".into())
+        .license("AGPL-3.0".into())
+        .build();
+
     let tray_menu = MenuBuilder::new(app)
         .items(&[
             &MenuItemBuilder::with_id("record", "Start Recording")
@@ -30,9 +41,7 @@ pub fn build(app: &AppHandle) {
             &MenuItemBuilder::with_id("feedback", "Give Feedback")
                 .build(app)
                 .expect(""),
-            &MenuItemBuilder::with_id("about", "About Helmer")
-                .accelerator("CommandOrControl+I")
-                .build(app)
+            &PredefinedMenuItem::about(app, "About Helmer Micro".into(), Some(about_metadata))
                 .expect(""),
             &PredefinedMenuItem::quit(app, Some("Quit")).expect(""),
         ])

--- a/src-tauri/src/tray/updater.rs
+++ b/src-tauri/src/tray/updater.rs
@@ -46,10 +46,13 @@ pub fn check_for_update(app_handle: AppHandle) -> Result<()> {
                                                         app_handle
                                                             .dialog()
                                                             .message("Update installed successfully!")
-                                                            .ok_button_label("Okay")
-                                                            .show(|_| {});
+                                                            .ok_button_label("Relaunch")
+                                                            .show(move |_| {
+                                                                app_handle.restart();
+                                                            });
                                                     }
                                                     Err(e) => {
+                                                        // TODO: handle a failed update
                                                         eprintln!("failed to install update: {}", e);
                                                     }
                                                     

--- a/src-tauri/src/tray/updater.rs
+++ b/src-tauri/src/tray/updater.rs
@@ -28,7 +28,7 @@ pub fn check_for_update(app_handle: AppHandle) -> Result<()> {
                                     tauri::async_runtime::spawn(async move {
                                         match result {
                                             true => {
-                                                let _ = update
+                                                let update_result = update
                                                     .clone()
                                                     .download_and_install(
                                                         |size, _| {
@@ -40,6 +40,20 @@ pub fn check_for_update(app_handle: AppHandle) -> Result<()> {
                                                         },
                                                     )
                                                     .await;
+
+                                                match update_result {
+                                                    Ok(_) => {
+                                                        app_handle
+                                                            .dialog()
+                                                            .message("Update installed successfully!")
+                                                            .ok_button_label("Okay")
+                                                            .show(|_| {});
+                                                    }
+                                                    Err(e) => {
+                                                        eprintln!("failed to install update: {}", e);
+                                                    }
+                                                    
+                                                }
                                             }
                                             _ => {}
                                         }

--- a/src-tauri/src/tray/updater.rs
+++ b/src-tauri/src/tray/updater.rs
@@ -12,29 +12,39 @@ pub fn check_for_update(app_handle: AppHandle) -> Result<()> {
                     Ok(update_option) => {
                         if let Some(update) = update_option {
                             let update_str = format!(
-                                "Current Version: {}\nLatest Version: {}",
+                                "Your Version: {}\nLatest Version: {}",
                                 update.current_version, update.version
                             );
 
-                            println!("{}", update_str);
+                            println!("update available:\n\tdownload url: {}", update.download_url);
 
                             app_handle
                                 .dialog()
                                 .message(update_str)
-                                .title("A new version of Helmer Micro is out!")
+                                .title("A new version is available!")
                                 .ok_button_label("Install")
                                 .cancel_button_label("Cancel")
-                                .show(|result| match result {
-                                    true => {
-                                        // TODO: install update
-                                        // update.download_and_install(None, None);
-                                    }
-                                    _ => {}
+                                .show(move |result| {
+                                    tauri::async_runtime::spawn(async move {
+                                        match result {
+                                            true => {
+                                                let _ = update
+                                                    .clone()
+                                                    .download_and_install(
+                                                        |size, _| {
+                                                            println!("downloading update...");
+                                                            println!("size: {}", size);
+                                                        },
+                                                        || {
+                                                            println!("update downloaded, proceeding to install!");
+                                                        },
+                                                    )
+                                                    .await;
+                                            }
+                                            _ => {}
+                                        }
+                                    });
                                 });
-                            println!(
-                                "update available:\n\tdownload url: {}\n\tsignature: {}",
-                                update.download_url, update.signature
-                            );
                         } else {
                             app_handle
                                 .dialog()


### PR DESCRIPTION
Adds the ability to check our update server for updates and download them from the tray menu if available. Tested working on my machine, but the code can be architected better perhaps. Looking for inputs on how to structure it.

To check if the changes in this PR are working correctly, change the version in your local `tauri.conf.json` to be one level lower and then run `yarn tauri build` to make yourself a binary. Once made, install it and test the update flow.