### PR TITLE
fix: mac screen recording permission issue

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "scap"
 version = "0.0.3"
-source = "git+https://github.com/helmerapp/scap/?branch=main#ed0eefd3ab8e7f8bcfe40afb34d7c1393d59de5c"
+source = "git+https://github.com/helmerapp/scap/?branch=main#92c750eb1ebfa9bc8a0986963547774327fbf6d0"
 dependencies = [
  "apple-sys",
  "bytes",
@@ -4128,11 +4128,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+checksum = "2c85f8e96d1d6857f13768fcbd895fcb06225510022a2774ed8b5150581847b0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.0",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4146,9 +4146,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.7.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+checksum = "c8b3a576c4eb2924262d5951a3b737ccaf16c931e39a2810c36f9a7e25575557"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5713,9 +5713,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -6112,9 +6112,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4e9d37c0bbf497cd42bc2e0ba12e0040ab42e454f2907dc1e9ddb2eaf52d34"
+checksum = "6e180ac2740d6cb4d5cec0abf63eacbea90f1b7e5e3803043b13c1c84c4b7884"
 dependencies = [
  "base64 0.22.0",
  "block",
@@ -6290,9 +6290,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
 
 [[package]]
 name = "zip"

--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -64,6 +64,12 @@ pub fn toggle_cropper(app: &AppHandle) {
 
     // TODO: figure out why the above doesn't work
     // Ask in Tauri Discord.
+
+    if !scap::has_permission() {
+        crate::open_onboarding(app);
+        return;
+    }
+
     if let Some(cropper_win) = app.get_webview_window("cropper") {
         match cropper_win.is_visible() {
             Ok(true) => {

--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -64,25 +64,24 @@ pub fn toggle_cropper(app: &AppHandle) {
 
     // TODO: figure out why the above doesn't work
     // Ask in Tauri Discord.
-
-    let cropper_win = app.get_webview_window("cropper").unwrap();
-    if cropper_win.is_visible().unwrap() {
-        cropper_win.hide().unwrap();
-
-        // reset cropper
-        cropper_win
-            .emit("reset-cropper", ())
-            .expect("couldn't reset cropper");
-
-        // always hide toolbar too, if it's visible
-        let toolbar_win = app
-            .get_webview_window("toolbar")
-            .expect("couldn't find toolbar");
-        if toolbar_win.is_visible().unwrap() {
-            toolbar_win.hide().unwrap();
+    if let Some(cropper_win) = app.get_webview_window("cropper") {
+        match cropper_win.is_visible() {
+            Ok(true) => {
+                cropper_win.hide().unwrap();
+                cropper_win
+                    .emit("reset-cropper", ())
+                    .expect("couldn't reset cropper");
+                if let Some(toolbar_win) = app.get_webview_window("toolbar") {
+                    if toolbar_win.is_visible().unwrap() {
+                        toolbar_win.hide().unwrap();
+                    }
+                }
+            }
+            Ok(false) => {
+                cropper_win.show().unwrap();
+                cropper_win.set_focus().unwrap();
+            }
+            Err(_) => {}
         }
-    } else {
-        cropper_win.show().unwrap();
-        cropper_win.set_focus().unwrap();
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -108,6 +108,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             recorder::start_recording,
             recorder::stop_recording,
+            recorder::request_recording_permission,
             editor::export_handler,
             toolbar::show_toolbar,
             toolbar::hide_toolbar

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -48,6 +48,12 @@ impl Default for AppState {
 const SHORTCUT: &str = "CmdOrCtrl+Shift+2";
 
 fn initialize_micro(app_handle: &AppHandle) {
+    // Build system tray
+    tray::build(&app_handle);
+
+    // Initialize cropping window
+    cropper::init_cropper(&app_handle);
+
     // Register global shortcut
     app_handle
         .plugin(
@@ -60,12 +66,6 @@ fn initialize_micro(app_handle: &AppHandle) {
                 .build(),
         )
         .expect("Failed to initialize global shortcut");
-
-    // Build system tray
-    tray::build(&app_handle);
-
-    // Initialize cropping window
-    cropper::init_cropper(&app_handle);
 }
 
 fn main() {
@@ -84,13 +84,6 @@ fn main() {
 
             store.load().unwrap_or_default();
 
-            let screen_recording_permission = scap::has_permission();
-
-            println!(
-                "Screen recording permission: {}",
-                screen_recording_permission
-            );
-
             // let first_run = true;
             let first_run = store
                 .get("first_run".to_string())
@@ -99,12 +92,11 @@ fn main() {
                 .unwrap();
 
             // If this is the first run, show onboarding screen
-            if first_run || !screen_recording_permission {
+            if first_run || !scap::has_permission() {
                 open_onboarding(app_handle);
 
                 // Set first run to false
                 store.insert("first_run".to_string(), false.into()).unwrap();
-
                 store.save().expect("Failed to save store")
             }
 
@@ -139,9 +131,8 @@ fn create_onboarding_win(app_handle: &AppHandle) {
     let mut onboarding_win =
         WebviewWindowBuilder::new(app_handle, "onboarding", WebviewUrl::App("/".into()))
             .accept_first_mouse(true)
-            .always_on_top(true)
-            .title("Helmer Micro")
             .inner_size(600.0, 580.0)
+            .title("Helmer Micro")
             .visible(true)
             .focused(true)
             .center();

--- a/src-tauri/src/recorder/mod.rs
+++ b/src-tauri/src/recorder/mod.rs
@@ -149,3 +149,8 @@ pub async fn stop_recording(app_handle: AppHandle) {
     *status = Status::Editing;
     drop(status);
 }
+
+#[tauri::command]
+pub async fn request_recording_permission(_: AppHandle) -> bool {
+    scap::request_permission()
+}

--- a/src-tauri/src/recorder/mod.rs
+++ b/src-tauri/src/recorder/mod.rs
@@ -1,6 +1,6 @@
 use std::{sync::mpsc, thread};
 
-use crate::{AppState, Status};
+use crate::{open_onboarding, AppState, Status};
 
 use tauri::{AppHandle, Manager};
 use tempfile::NamedTempFile;
@@ -12,6 +12,13 @@ use henx::{VideoEncoder, VideoEncoderOptions};
 
 #[tauri::command]
 pub async fn start_recording(app_handle: AppHandle) {
+    // If no permissions, open onboarding screen
+    if !scap::has_permission() {
+        eprintln!("no permission to record screen");
+        open_onboarding(&app_handle);
+        return;
+    }
+
     let app_handle_clone = app_handle.clone();
     start_frame_capture(app_handle_clone).await;
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -57,12 +57,17 @@ import Titlebar from "../components/titlebar.astro";
 </Base>
 
 <script>
+	import { invoke } from "@tauri-apps/api/core";
 	import { getCurrent } from "@tauri-apps/api/window";
 
 	const button = document.querySelector("button") as HTMLButtonElement;
 
 	button.addEventListener("click", async () => {
-		await getCurrent().close();
+		invoke("request_recording_permission").then((response) => {
+			if (response) {
+				getCurrent().close().then();
+			}
+		});
 	});
 </script>
 


### PR DESCRIPTION
People were having trouble granting screen recording permissions on macOS. With this PR, I have put in a bunch of guardrails in place and made it so that the onboarding window button will directly open the security settings on macOS.

Companion `scap` PR: https://github.com/helmerapp/scap/pull/52