### PR TITLE
feat: render cropper above standard macos apps

### DIFF
--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -41,6 +41,9 @@ pub fn init_cropper(app: &AppHandle) {
                 let id = cropper_win.ns_window().unwrap() as cocoa::base::id;
 
                 unsafe {
+                    // set window level to 25
+                    let _: cocoa::base::id = msg_send![id, setLevel: 25];
+                    
                     // Make the webview and window background transparent
                     let color =
                     NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 0.0);

--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -43,7 +43,7 @@ pub fn init_cropper(app: &AppHandle) {
 
                 unsafe {
                     // set window level
-                    // let _: cocoa::base::id = msg_send![id, setLevel: 25];
+                    let _: cocoa::base::id = msg_send![id, setLevel: 25];
 
                      // Make the webview and window background transparent
                     let color =

--- a/src-tauri/src/toolbar/mod.rs
+++ b/src-tauri/src/toolbar/mod.rs
@@ -35,9 +35,11 @@ pub fn init_toolbar(app: &AppHandle) {
         .to_owned()
         .run_on_main_thread(move || unsafe {
             let id = toolbar_win.ns_window().unwrap() as cocoa::base::id;
+
+            // TODO: recording crashes if menubar is actually part of the croparea
             
             // set window level
-            // let _: cocoa::base::id = msg_send![id, setLevel: 26];
+            let _: cocoa::base::id = msg_send![id, setLevel: 26];
 
             let color =
                 NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 0.0);

--- a/src-tauri/src/toolbar/mod.rs
+++ b/src-tauri/src/toolbar/mod.rs
@@ -33,19 +33,24 @@ pub fn init_toolbar(app: &AppHandle) {
 
         toolbar_win
             .to_owned()
-            .run_on_main_thread(move || unsafe {
+            .run_on_main_thread(move || {
                 let id = toolbar_win.ns_window().unwrap() as cocoa::base::id;
 
-                let color =
-                    NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 0.0);
-                let _: cocoa::base::id = msg_send![id, setBackgroundColor: color];
-                toolbar_win.with_webview(|webview| {
-                    // !!! has delay
-                    let id = webview.inner();
-                    let no: cocoa::base::id = msg_send![class!(NSNumber), numberWithBool:0];
-                    let _: cocoa::base::id =
-                            msg_send![id, setValue:no forKey: NSString::alloc(nil).init_str("drawsBackground")];
-                }).ok();
+                unsafe {
+                    // set window level to 26
+                    let _: cocoa::base::id = msg_send![id, setLevel: 26];
+
+                    let color =
+                        NSColor::colorWithSRGBRed_green_blue_alpha_(nil, 0.0, 0.0, 0.0, 0.0);
+                    let _: cocoa::base::id = msg_send![id, setBackgroundColor: color];
+                    toolbar_win.with_webview(|webview| {
+                        // !!! has delay
+                        let id = webview.inner();
+                        let no: cocoa::base::id = msg_send![class!(NSNumber), numberWithBool:0];
+                        let _: cocoa::base::id =
+                                msg_send![id, setValue:no forKey: NSString::alloc(nil).init_str("drawsBackground")];
+                    }).ok();
+                }
             })
         .unwrap();
     }


### PR DESCRIPTION
Basically, the cropper window renders "under" the macOS menubar as shown below:
<img width="1498" alt="Screenshot 2024-04-26 at 10 17 49 AM" src="https://github.com/helmerapp/micro/assets/30227512/37b843b4-ecc3-4e19-bed3-807adbdac666">

I would like it to render "above", like how Quicktime recorder does.
![Screenshot 2024-04-26 at 10 19 25 AM](https://github.com/helmerapp/micro/assets/30227512/0ca9dba1-964a-4727-be2b-0da7bb04cc9f)

My idea is to use the raw window handle that Tauri exposes (on macOS via NSWindow) and see if we can write some Rust/Swift/ObjC code to get it working.