### PR TITLE
fix: select all frames by default on opening editor

### DIFF
--- a/src/components/editor/index.tsx
+++ b/src/components/editor/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core'
 
 import CONSTANTS from '../../constants';
@@ -12,6 +12,10 @@ export default function Editor() {
 	const [exporting, setExporting] = useState(false);
 	const [totalFrames, setTotalFrames] = useState(0);
 	const [selectedFrames, setSelectedFrames] = useState([0, totalFrames]);
+
+	useEffect(() => {
+		setSelectedFrames([0, totalFrames]);
+	}, [totalFrames]);
 
 	const exportHandler = (options: {
 		fps: number,


### PR DESCRIPTION
Before change:
<img width="604" alt="image" src="https://github.com/helmerapp/micro/assets/20909078/a1ed0d0a-e4c9-4713-b317-3b6a5225ba56">



After change:
<img width="604" alt="image" src="https://github.com/helmerapp/micro/assets/20909078/30999571-82f3-4856-8eef-49a0a4a36291">
