### PR TITLE
refactor: removes status enum

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,29 +16,19 @@ use tokio::sync::Mutex;
 #[cfg(target_os = "macos")]
 use tauri::ActivationPolicy;
 
-#[derive(Debug, PartialEq)]
-pub enum Status {
-    Idle,
-    Cropper,
-    Recording,
-    Editing,
-}
-
 pub struct AppState {
-    cropped_area: Mutex<Vec<u32>>,
-    status: Mutex<Status>,
     frames: Mutex<Vec<Frame>>,
     recorder: Mutex<Option<Capturer>>,
+    cropped_area: Mutex<Vec<u32>>,
     preview_path: Mutex<Option<PathBuf>>,
 }
 
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            cropped_area: Mutex::new(Vec::new()),
-            status: Mutex::new(Status::Idle),
             frames: Mutex::new(Vec::new()),
             recorder: Mutex::new(None),
+            cropped_area: Mutex::new(Vec::new()),
             preview_path: Mutex::new(None),
         }
     }

--- a/src-tauri/src/recorder/mod.rs
+++ b/src-tauri/src/recorder/mod.rs
@@ -1,6 +1,6 @@
 use std::{sync::mpsc, thread};
 
-use crate::{open_onboarding, AppState, Status};
+use crate::{open_onboarding, AppState};
 
 use tauri::{AppHandle, Manager};
 use tempfile::NamedTempFile;
@@ -146,11 +146,6 @@ pub async fn stop_recording(app_handle: AppHandle) {
     (*recorder).as_mut().unwrap().stop_capture();
     recorder.take();
     drop(recorder);
-
-    // Update app state to editing
-    let mut status = state.status.lock().await;
-    *status = Status::Editing;
-    drop(status);
 }
 
 #[tauri::command]

--- a/src-tauri/src/recorder/utils.rs
+++ b/src-tauri/src/recorder/utils.rs
@@ -1,4 +1,4 @@
-use crate::{AppState, Status};
+use crate::AppState;
 use rand::Rng;
 use scap::{
     capturer::{CGPoint, CGRect, CGSize, Capturer, Options, Resolution},
@@ -10,10 +10,6 @@ pub const FRAME_TYPE: FrameType = FrameType::BGRAFrame;
 
 pub async fn start_frame_capture(app_handle: AppHandle) {
     let state = app_handle.state::<AppState>();
-
-    let mut status = state.status.lock().await;
-    *status = Status::Recording;
-    drop(status);
 
     // area is of the form [x1, y1, x2, y2]
     // we need it of the form [x1, y1, x2-x1, y2-y1]


### PR DESCRIPTION
lol, realized that the Status enum in our AppState literally does not do anything. Removed it for now. Ideally we would use Tauri's event mechanism to cascade any "state" change but it is not needed for the time being.