### PR TITLE
fix: adjust for fractional scaling when recording on windows platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // NEED THE VSCODE LLDB EXT FOR THIS.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "lldb",
+        "request": "launch",
+        "name": "Tauri Development Debug",
+        "cargo": {
+          "args": [
+            "build",
+            "--manifest-path=./src-tauri/Cargo.toml",
+            "--no-default-features"
+          ]
+        },
+        // task for the `beforeDevCommand` if used, must be configured in `.vscode/tasks.json`
+        "preLaunchTask": "ui:dev"
+      },
+      {
+        "type": "lldb",
+        "request": "launch",
+        "name": "Tauri Production Debug",
+        "cargo": {
+          "args": ["build", "--release", "--manifest-path=./src-tauri/Cargo.toml"]
+        },
+        // task for the `beforeBuildCommand` if used, must be configured in `.vscode/tasks.json`
+        "preLaunchTask": "ui:build"
+      }
+    ]
+  }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "ui:dev",
+        "type": "shell",
+        // `dev` keeps running in the background
+        // ideally you should also configure a `problemMatcher`
+        // see https://code.visualstudio.com/docs/editor/tasks#_can-a-background-task-be-used-as-a-prelaunchtask-in-launchjson
+        "isBackground": true,
+        // change this to your `beforeDevCommand`:
+        "command": "yarn",
+        "args": ["dev"]
+      },
+      {
+        "label": "ui:build",
+        "type": "shell",
+        // change this to your `beforeBuildCommand`:
+        "command": "yarn",
+        "args": ["build"]
+      }
+    ]
+  }

--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -56,6 +56,10 @@ fn create_cropper_win(app: &AppHandle) {
     let scale_factor = primary_monitor.scale_factor();
     let monitor_size = primary_monitor.size().to_logical(scale_factor);
 
+    // println!("MONITOR DIMENSIONS: {:?}", monitor_size);
+    
+    // println!("ScaleFactor: {:?}", scale_factor);
+
     // create cropper window
     let mut cropper_win =
         WebviewWindowBuilder::new(app, "cropper", WebviewUrl::App("/cropper".into()))
@@ -64,6 +68,7 @@ fn create_cropper_win(app: &AppHandle) {
             .accept_first_mouse(true)
             .skip_taskbar(true)
             .position(0.0, 0.0)
+            .fullscreen(true)
             .always_on_top(true)
             .decorations(false)
             .resizable(false)

--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -68,7 +68,6 @@ fn create_cropper_win(app: &AppHandle) {
             .accept_first_mouse(true)
             .skip_taskbar(true)
             .position(0.0, 0.0)
-            .fullscreen(true)
             .always_on_top(true)
             .decorations(false)
             .resizable(false)


### PR DESCRIPTION
## Context
If you are using fractional scaling (windows display setting, called different in other platforms) , we observe that the recorded areas are incorrect. 

They are offset by a certain ratio. this is incorrect (obviously)

## Description
we are multiplying the coordinates with the scale_factor

## Changes in the codebase
multiplications with scale_factor before passing in options to scap.

## Considerations for future
need to test on mac and *nix (especially those with scale factors other than 1)

## Additional Information
scap takes in `CGPoint` and `CGSize`.