### PR TITLE
feat: multi-display support (macOS)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -741,8 +741,8 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -834,6 +834,19 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
@@ -841,7 +854,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -854,7 +867,7 @@ dependencies = [
  "bitflags 2.5.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1359,12 +1372,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1377,6 +1399,12 @@ dependencies = [
  "quote",
  "syn 2.0.66",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2558,6 +2586,7 @@ dependencies = [
  "gifski",
  "henx",
  "imgref",
+ "mouse_position",
  "objc",
  "opener",
  "os_info",
@@ -2619,6 +2648,17 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mouse_position"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824feb0675ad2ffda7b1da534f394c5779fb39d123b5f376a221d50fad54b3c2"
+dependencies = [
+ "core-graphics 0.22.3",
+ "winapi",
+ "x11-dl",
 ]
 
 [[package]]
@@ -4199,8 +4239,8 @@ checksum = "d09e57a5a6b300bf917329da0ff30a58737d83abb7b14f99a419c23e83007cb8"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -4382,7 +4422,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cocoa",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.23.2",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -5166,7 +5206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad8319cca93189ea9ab1b290de0595960529750b6b8b501a399ed1ec3775d60"
 dependencies = [
  "cocoa",
- "core-graphics",
+ "core-graphics 0.23.2",
  "crossbeam-channel",
  "dirs",
  "libappindicator",
@@ -5994,7 +6034,7 @@ dependencies = [
  "base64 0.22.1",
  "block",
  "cocoa",
- "core-graphics",
+ "core-graphics 0.23.2",
  "crossbeam-channel",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -16,17 +16,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
 
 [[package]]
 name = "ahash"
@@ -62,27 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
-]
-
-[[package]]
-name = "alsa"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fe60779335388a88c01ac6c3be40304d1e349de3ada3b15f7808bb90fa9dce"
-dependencies = [
- "alsa-sys",
- "bitflags 2.5.0",
- "libc",
-]
-
-[[package]]
-name = "alsa-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
-dependencies = [
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -142,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -161,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apple-bindgen-helmer-fork"
@@ -204,6 +172,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,12 +205,12 @@ dependencies = [
 
 [[package]]
 name = "async-broadcast"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258b52a1aa741b9f09783b2d86cf0aeeb617bbf847f6933340a39644227acbdb"
+checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
 dependencies = [
- "event-listener 5.3.0",
- "event-listener-strategy 0.5.2",
+ "event-listener",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
@@ -245,16 +222,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener-strategy 0.5.2",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
+checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -276,9 +253,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+checksum = "0d6baa8f0178795da0e71bc42c9e5d13261aac7ee549853162e66a241ba17964"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -295,20 +272,20 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener",
+ "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-process"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
+checksum = "f7eda79bbd84e29c2b308d1dc099d7de8dcc7035e48f4bf5dc4a531a44ff5e2a"
 dependencies = [
  "async-channel",
  "async-io",
@@ -317,7 +294,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.0",
+ "event-listener",
  "futures-lite",
  "rustix",
  "tracing",
@@ -332,14 +309,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
+checksum = "329972aa325176e89114919f2a80fdae4f4c040f66a370b1a1159c6c0f94e7aa"
 dependencies = [
  "async-io",
  "async-lock",
@@ -367,7 +344,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -407,9 +384,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
 dependencies = [
  "addr2line",
  "cc",
@@ -433,12 +410,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bindgen"
 version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,15 +429,9 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.64",
+ "syn 2.0.66",
  "which",
 ]
-
-[[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -499,13 +464,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.6.0"
+name = "block2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
  "async-channel",
- "async-lock",
  "async-task",
  "futures-io",
  "futures-lite",
@@ -569,27 +542,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -661,14 +613,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
-dependencies = [
- "jobserver",
- "libc",
- "once_cell",
-]
+checksum = "96c51067fd44124faa7f870b4b1c969379ad32b2ba805aa959430ceaa384f695"
 
 [[package]]
 name = "cesu8"
@@ -734,20 +681,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "clang-sys"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
@@ -756,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "a9689a29b593160de5bc4aacab7b5d54fb52231de70122626c178e6a368994c7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -766,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "2e5387378c84f6faa26890ebf9f0a92989f8873d4d380467bcd0d8d8620424df"
 dependencies = [
  "anstream",
  "anstyle",
@@ -778,21 +715,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cocoa"
@@ -854,12 +791,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -939,49 +870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coreaudio-rs"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f01585027057ff5f0a5bf276174ae4c1594a2c5bde93d5f46a016d76270f5a9"
-dependencies = [
- "bindgen",
-]
-
-[[package]]
-name = "cpal"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
-dependencies = [
- "alsa",
- "core-foundation-sys",
- "coreaudio-rs",
- "dasp_sample",
- "jni",
- "js-sys",
- "libc",
- "mach2",
- "ndk 0.8.0",
- "ndk-context",
- "oboe",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "windows 0.54.0",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,18 +880,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1029,15 +917,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -1073,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1083,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1107,7 +989,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1118,14 +1000,8 @@ checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
-
-[[package]]
-name = "dasp_sample"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dbus"
@@ -1160,6 +1036,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,7 +1067,15 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
 ]
 
 [[package]]
@@ -1191,6 +1086,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1211,12 +1118,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.3",
 ]
 
 [[package]]
@@ -1239,7 +1157,7 @@ checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1259,9 +1177,9 @@ checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
 
 [[package]]
 name = "dtoa-short"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbaceec3c6e4211c79e7b1800fb9680527106beb2f9c51904a3210c03a448c74"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
@@ -1321,9 +1239,9 @@ checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3278c9d5fb675e0a51dabcf4c0d355f692b064171535ba72361be1528a9d8e8d"
+checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -1331,13 +1249,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c785274071b1b420972453b306eeca06acf4633829db4223b58a2a8c5953bc4"
+checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1358,33 +1276,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -1394,24 +1291,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 5.3.0",
+ "event-listener",
  "pin-project-lite",
-]
-
-[[package]]
-name = "exr"
-version = "1.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
-dependencies = [
- "bit_field",
- "flume",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
 ]
 
 [[package]]
@@ -1471,15 +1352,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,7 +1375,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1600,7 +1472,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1777,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1792,7 +1664,6 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
 dependencies = [
- "color_quant",
  "weezl",
 ]
 
@@ -1830,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "gio"
@@ -1900,7 +1771,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1921,9 +1792,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "global-hotkey"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf13ae557ac61fa8f6fa949c33616e9680f0f04a9dd0195cd210770ba643f1a"
+checksum = "89cb13e8c52c87e28a46eae3e5e65b8f0cd465c4c9e67b13d56c70412e792bc3"
 dependencies = [
  "bitflags 2.5.0",
  "cocoa",
@@ -1997,17 +1868,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
-]
-
-[[package]]
-name = "half"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
-dependencies = [
- "cfg-if",
- "crunchy",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -2046,12 +1907,12 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "henx"
 version = "0.1.0"
-source = "git+https://github.com/helmerapp/henx/?branch=main#7941cd26b7f14126a47a3ae574a99657533bacdb"
+source = "git+https://github.com/helmerapp/henx/?branch=main#3fde1a75d384727a35f77bfb38b92484355da45d"
 dependencies = [
  "anyhow",
  "scap",
  "swift-rs",
- "windows-capture",
+ "windows-capture 1.2.0 (git+https://github.com/NiiightmareXD/windows-capture?branch=main)",
 ]
 
 [[package]]
@@ -2067,15 +1928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,12 +1935,6 @@ checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "hound"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
@@ -2188,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2264,13 +2110,8 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "exr",
- "gif",
- "jpeg-decoder",
  "num-traits",
  "png",
- "qoi",
- "tiff",
 ]
 
 [[package]]
@@ -2324,19 +2165,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -2439,24 +2271,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
-dependencies = [
- "rayon",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,12 +2327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libdbus-sys"
@@ -2687,15 +2495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
-name = "mach2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2755,6 +2554,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "cocoa",
+ "core-graphics-helmer-fork",
  "gifski",
  "henx",
  "imgref",
@@ -2763,6 +2563,7 @@ dependencies = [
  "os_info",
  "rand 0.8.5",
  "rgb",
+ "runtime",
  "scap",
  "serde",
  "serde_json",
@@ -2775,6 +2576,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
+ "tauri-runtime-wry",
  "tauri-utils",
  "tempfile",
  "tokio",
@@ -2801,9 +2603,9 @@ checksum = "933dca44d65cdd53b355d0b73d380a2ff5da71f87f036053188bf1eab6a19881"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
  "simd-adler32",
@@ -2822,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1717c136c99673f55640c14125a0349a5cd7fee6efcfb0adbfe4c289e3b3f7f2"
+checksum = "86b959f97c97044e4c96e32e1db292a7d594449546a3c6b77ae613dc3a5b5145"
 dependencies = [
  "cocoa",
  "crossbeam-channel",
@@ -2847,23 +2649,9 @@ checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
 dependencies = [
  "bitflags 1.3.2",
  "jni-sys",
- "ndk-sys 0.4.1+23.1.7779620",
+ "ndk-sys",
  "num_enum 0.5.11",
  "raw-window-handle 0.5.2",
- "thiserror",
-]
-
-[[package]]
-name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.5.0",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum 0.7.2",
  "thiserror",
 ]
 
@@ -2878,15 +2666,6 @@ name = "ndk-sys"
 version = "0.4.1+23.1.7779620"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
-dependencies = [
- "jni-sys",
-]
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
 ]
@@ -2969,17 +2748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.64",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,7 +2805,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3062,6 +2830,105 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.5.0",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
 name = "objc_exception"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3081,34 +2948,11 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -3119,9 +2963,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "open"
-version = "5.1.3"
+version = "5.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb49fbd5616580e9974662cb96a3463da4476e649a7e4b258df0de065db0657"
+checksum = "b5ca541f22b1c46d4bb9801014f234758ab4297e7870b904b6a8415b980a7388"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3138,6 +2982,12 @@ dependencies = [
  "normpath",
  "winapi",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-channel"
@@ -3170,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.1.5"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3217,9 +3067,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3239,33 +3089,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -3377,7 +3204,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3424,7 +3251,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3441,9 +3268,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464db0c665917b13ebb5d453ccdec4add5658ee1adc7affc7677615356a8afaf"
+checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -3513,9 +3340,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
+checksum = "5e6a007746f34ed64099e88783b0ae369eaa3da6392868ba262e2af9b8fbaea1"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -3551,7 +3378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -3606,20 +3433,11 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "22244ce15aa966053a896d1accb3a6e68469b97c7f33f284b99f0d576879fc23"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -3706,7 +3524,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -3735,9 +3553,9 @@ checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "raw-window-handle"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc3bcbdb1ddfc11e700e62968e6b4cc9c75bb466464ad28fb61c5b2c964418b"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
@@ -3783,7 +3601,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -3902,7 +3720,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3926,12 +3744,18 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "runtime"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485bae53d3b7af75e4e8c4881ba084d0f5a88913c8cb7a3572522aea706bca32"
 
 [[package]]
 name = "rustc-demangle"
@@ -4031,17 +3855,14 @@ dependencies = [
 
 [[package]]
 name = "scap"
-version = "0.0.4"
-source = "git+https://github.com/helmerapp/scap/?branch=main#65a5c2acbede0d060cf2f97af1754182733dba52"
+version = "0.0.5"
+source = "git+https://github.com/helmerapp/scap/?branch=main#8c1b76e09eb667a9091d34a15fc2898d7a8ae17c"
 dependencies = [
  "apple-sys-helmer-fork",
- "bytes",
+ "cocoa",
  "core-graphics-helmer-fork",
- "cpal",
  "dbus",
- "hound",
- "image",
- "itertools",
+ "objc",
  "pipewire",
  "rand 0.8.5",
  "screencapturekit",
@@ -4049,14 +3870,14 @@ dependencies = [
  "sysinfo",
  "tao-core-video-sys",
  "windows 0.52.0",
- "windows-capture",
+ "windows-capture 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "schemars"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6e7ed6919cb46507fb01ff1654309219f62b4d603822501b0b80d42f6f21ef"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
@@ -4068,14 +3889,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.19"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185f2b7aa7e02d418e453790dde16890256bbd2bcd04b7dc5348811052b53f49"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4144,22 +3965,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4170,7 +3991,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4192,7 +4013,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4243,7 +4064,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -4373,19 +4194,21 @@ dependencies = [
 
 [[package]]
 name = "softbuffer"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61d5d17f23326fe0d9b0af282f73f3af666699420fd5f42629efd9c6e7dc166f"
+checksum = "d09e57a5a6b300bf917329da0ff30a58737d83abb7b14f99a419c23e83007cb8"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "cocoa",
  "core-graphics",
  "foreign-types",
  "js-sys",
  "log",
- "objc",
- "raw-window-handle 0.6.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "raw-window-handle 0.6.2",
  "redox_syscall 0.5.1",
  "wasm-bindgen",
  "wayland-sys",
@@ -4424,9 +4247,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -4511,9 +4331,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.64"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad3dee41f36859875573074334c200d1add8e4a87bb37113ebd31d926b7b11f"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4576,13 +4396,13 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "ndk 0.7.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.4.1+23.1.7779620",
+ "ndk-sys",
  "objc",
  "once_cell",
  "parking_lot",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "scopeguard",
  "tao-macros",
  "unicode-segmentation",
@@ -4618,9 +4438,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",
@@ -4635,9 +4455,9 @@ checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
 name = "tauri"
-version = "2.0.0-beta.19"
+version = "2.0.0-beta.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8e5bc2e4f5eb7496d1a3e5f4d272f69f1333db5f8efed28d79d7f93334fe95"
+checksum = "5a258ecc5ac7ddade525f512c4962fd01cd0f5265e917b4572579c32c027bb31"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4646,7 +4466,7 @@ dependencies = [
  "dunce",
  "embed_plist",
  "futures-util",
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
  "glob",
  "gtk",
  "heck 0.5.0",
@@ -4660,7 +4480,7 @@ dependencies = [
  "muda",
  "objc",
  "percent-encoding",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -4686,9 +4506,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.0.0-beta.15"
+version = "2.0.0-beta.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aa28eebafcda490fa7097a6e3a4d07f65967614d35dd88b2aaa19dbb49241cd"
+checksum = "82b964bb6d03d97e24e12f896aab463b02a3c2ff76a60f728cc37b5548eb470e"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4708,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.0-beta.15"
+version = "2.0.0-beta.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727d13a28e9ec895f537d90a09acb0aa3593f703a715fe8a77f87269d3245b52"
+checksum = "3529cfa977ed7c097f2a5e8da19ecffbe61982450a6c819e6165b6d0cfd3dd3a"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4724,7 +4544,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.64",
+ "syn 2.0.66",
  "tauri-utils",
  "thiserror",
  "time",
@@ -4735,23 +4555,23 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.0-beta.15"
+version = "2.0.0-beta.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258667612ad901d256e04ace71ac54d4b3dd8fb1e5baa24403b50991cade4365"
+checksum = "36f97dd80334f29314aa5f40b5fad10cb9feffd08e5a5324fd728613841e5d33"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "tauri-codegen",
  "tauri-utils",
 ]
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.0-beta.15"
+version = "2.0.0-beta.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4b2f5a6ebff6558445ac0c54171e599abf1cddf9da539b043af74a46d2c04ce"
+checksum = "7c8385fd0a4f661f5652b0d9e2d7256187d553bb174f88564d10ebcfa6a3af53"
 dependencies = [
  "anyhow",
  "glob",
@@ -4767,7 +4587,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-decorum"
 version = "0.1.0"
-source = "git+https://github.com/clearlysid/tauri-plugin-decorum?branch=main#d29eb472b5182b5ec5b49f166cd47f3bd73ceeed"
+source = "git+https://github.com/clearlysid/tauri-plugin-decorum?branch=main#3584283c93e775e4c5ea0d1351019052f9e896bf"
 dependencies = [
  "anyhow",
  "cocoa",
@@ -4782,13 +4602,13 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.0.0-beta.7"
+version = "2.0.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4563f62939a475273e7b75eb4a862f0108969a54db813ef250092d470eff84dc"
+checksum = "fed4b22c59f7b04ae2a0bed8241aa715b41973c3f042c84aa67a1f4dc0174a8d"
 dependencies = [
  "dunce",
  "log",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "rfd",
  "serde",
  "serde_json",
@@ -4800,9 +4620,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.0.0-beta.7"
+version = "2.0.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35377195c6923beda5f29482a16b492d431de964389fca9aaf81a0f7e908023f"
+checksum = "3aa91955751f329e0aa431b87c199b7378b6f91ec0765d2ad9d4c64e017c3cda"
 dependencies = [
  "anyhow",
  "glob",
@@ -4819,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-global-shortcut"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1cfbcbb0b13ba15d23790d2148d9242d40b10d0e7a6879901bb8530d77ef4"
+checksum = "b2373253fdd9c72f3ae7d26258a8fc92c691884a982aaa65b9798bf44dfa079e"
 dependencies = [
  "global-hotkey",
  "log",
@@ -4834,9 +4654,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-shell"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4973141725f74983f6e89b9ce9c69a18bc0ec0fba23cc4d022986e0325b92b"
+checksum = "f8675bf7ab71f571a99192d0685ae870eb7af1264bdbbb66a1d655609f6c7ebd"
 dependencies = [
  "encoding_rs",
  "log",
@@ -4855,9 +4675,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.0.0-beta.7"
+version = "2.0.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3098fb51fa173551b1ebe417cfb4b7710943011bc4de37c2d1c6c6ea1dca98"
+checksum = "0ecafcc5214a5d3cd7a720c11e9c03cbd45ccaff721963485ec4ab481bdf4540"
 dependencies = [
  "log",
  "serde",
@@ -4870,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-store"
-version = "2.0.0-beta.6"
+version = "2.0.0-beta.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f378253a5b593a4c08fab0b6e6e05b58cd2d4caf9ccca532e18c98c25790d5df"
+checksum = "7a714175f639b050b121c74b6281724f4b00e080a5a71c6821004c8aa89f8943"
 dependencies = [
  "dunce",
  "log",
@@ -4885,9 +4705,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-updater"
-version = "2.0.0-beta.5"
+version = "2.0.0-beta.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1a632f5b0cc00911c3f379b0b69a4ccf5fd22eb10d022010dfb02717d5b6bc"
+checksum = "dd8b0bec1fe304e1ff350b5e7be5048047f9bdec19dcc224ba266e9f2a692b8e"
 dependencies = [
  "base64 0.22.1",
  "dirs-next",
@@ -4914,15 +4734,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574f3d59cbe6c76b6d849bc35aa3a9e8061ff8f75f557dc33f38c0e43cf55a41"
+checksum = "d7dc96172a43536236ab55b7da7b8461bf75810985e668589e2395cb476937cb"
 dependencies = [
  "dpi",
  "gtk",
  "http",
  "jni",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -4933,9 +4753,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.0.0-beta.16"
+version = "2.0.0-beta.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d1f223de1d674aaa561c900ac650b3160f11520e9b191a3574f6c493fc77fa"
+checksum = "5d4fd913b1f14a9b618c7f3ae35656d3aa759767fcb95b72006357c12b9d0b09"
 dependencies = [
  "cocoa",
  "gtk",
@@ -4943,7 +4763,7 @@ dependencies = [
  "jni",
  "log",
  "percent-encoding",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "softbuffer",
  "tao",
  "tauri-runtime",
@@ -4957,16 +4777,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.0-beta.15"
+version = "2.0.0-beta.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4251529d92b5c611ccaa611f8a31cb41b1aa00db8bcc0a49efe5d966bfa911"
+checksum = "4f24a9c20d676a3f025331cc1c3841256ba88c9f25fb7fae709d2b3089c50d90"
 dependencies = [
  "brotli",
  "cargo_metadata",
  "ctor",
  "dunce",
  "glob",
- "heck 0.5.0",
  "html5ever",
  "infer",
  "json-patch",
@@ -5031,22 +4850,22 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5057,17 +4876,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
 ]
 
 [[package]]
@@ -5118,9 +4926,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5138,13 +4946,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5277,7 +5085,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5298,7 +5105,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5312,7 +5118,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5356,14 +5162,14 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39240037d755a1832e752d64f99078c3b0b21c09a71c12405070c75ef4e7cd3c"
+checksum = "3ad8319cca93189ea9ab1b290de0595960529750b6b8b501a399ed1ec3775d60"
 dependencies = [
  "cocoa",
  "core-graphics",
  "crossbeam-channel",
- "dirs-next",
+ "dirs",
  "libappindicator",
  "muda",
  "objc",
@@ -5467,9 +5273,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "untrusted"
@@ -5510,9 +5316,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -5520,7 +5326,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom 0.2.14",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -5613,7 +5419,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "wasm-bindgen-shared",
 ]
 
@@ -5647,7 +5453,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5673,9 +5479,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+checksum = "105b1842da6554f91526c14a2a2172897b7f745a805d62af4ce698706be79c12"
 dependencies = [
  "dlib",
  "log",
@@ -5738,9 +5544,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5767,7 +5573,7 @@ checksum = "ac1345798ecd8122468840bcdf1b95e5dc6d2206c5e4b0eafa078d061f59c9bc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5838,7 +5644,7 @@ checksum = "33082acd404763b315866e14a0d5193f3422c81086657583937a750cdd3ec340"
 dependencies = [
  "cocoa",
  "objc",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "windows-sys 0.52.0",
  "windows-version",
 ]
@@ -5859,16 +5665,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core 0.52.0",
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
  "windows-targets 0.52.5",
 ]
 
@@ -5895,21 +5691,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-capture"
+version = "1.2.0"
+source = "git+https://github.com/NiiightmareXD/windows-capture?branch=main#6552bace24d60415ca3501ff8d3f38335cd5b26f"
+dependencies = [
+ "parking_lot",
+ "rayon",
+ "thiserror",
+ "windows 0.56.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result",
  "windows-targets 0.52.5",
 ]
 
@@ -5933,7 +5730,7 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -5944,14 +5741,14 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749f0da9cc72d82e600d8d2e44cadd0b9eedb9038f71a1c58556ac1c5791813b"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.5",
 ]
@@ -6191,9 +5988,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.39.5"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7172fc76376d55d089c627a31a5b604b4ac372793fb5378d1c7ddf008703008"
+checksum = "1fa597526af53f310a8e6218630c5024fdde8271f229e70d7d2fc70b52b8fb1e"
 dependencies = [
  "base64 0.22.1",
  "block",
@@ -6210,14 +6007,14 @@ dependencies = [
  "jni",
  "kuchikiki",
  "libc",
- "ndk 0.7.0",
+ "ndk",
  "ndk-context",
- "ndk-sys 0.4.1+23.1.7779620",
+ "ndk-sys",
  "objc",
  "objc_id",
  "once_cell",
  "percent-encoding",
- "raw-window-handle 0.6.1",
+ "raw-window-handle 0.6.2",
  "sha2",
  "soup3",
  "tao-macros",
@@ -6265,12 +6062,12 @@ dependencies = [
 
 [[package]]
 name = "xdg-home"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e"
+checksum = "ca91dcf8f93db085f3a0a29358cd0b9d670915468f4290e8b85d118a34211ab8"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6300,7 +6097,7 @@ dependencies = [
  "blocking",
  "derivative",
  "enumflags2",
- "event-listener 5.3.0",
+ "event-listener",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -6364,71 +6161,28 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.64",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
 dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
+ "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
+ "displaydoc",
+ "indexmap 2.2.6",
+ "num_enum 0.7.2",
+ "thiserror",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -741,8 +741,8 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -834,6 +834,19 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types 0.3.2",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
@@ -841,7 +854,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -854,7 +867,7 @@ dependencies = [
  "bitflags 2.5.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1359,12 +1372,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1377,6 +1399,12 @@ dependencies = [
  "quote",
  "syn 2.0.66",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2558,6 +2586,7 @@ dependencies = [
  "gifski",
  "henx",
  "imgref",
+ "mouse_position",
  "objc",
  "opener",
  "os_info",
@@ -2620,6 +2649,17 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mouse_position"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824feb0675ad2ffda7b1da534f394c5779fb39d123b5f376a221d50fad54b3c2"
+dependencies = [
+ "core-graphics 0.22.3",
+ "winapi",
+ "x11-dl",
 ]
 
 [[package]]
@@ -4200,8 +4240,8 @@ checksum = "d09e57a5a6b300bf917329da0ff30a58737d83abb7b14f99a419c23e83007cb8"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "core-graphics",
- "foreign-types",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -4383,7 +4423,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cocoa",
  "core-foundation",
- "core-graphics",
+ "core-graphics 0.23.2",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -5167,7 +5207,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad8319cca93189ea9ab1b290de0595960529750b6b8b501a399ed1ec3775d60"
 dependencies = [
  "cocoa",
- "core-graphics",
+ "core-graphics 0.23.2",
  "crossbeam-channel",
  "dirs",
  "libappindicator",
@@ -5995,7 +6035,7 @@ dependencies = [
  "base64 0.22.1",
  "block",
  "cocoa",
- "core-graphics",
+ "core-graphics 0.23.2",
  "crossbeam-channel",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -741,8 +741,8 @@ dependencies = [
  "block",
  "cocoa-foundation",
  "core-foundation",
- "core-graphics 0.23.2",
- "foreign-types 0.5.0",
+ "core-graphics",
+ "foreign-types",
  "libc",
  "objc",
 ]
@@ -834,19 +834,6 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types 0.3.2",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
@@ -854,7 +841,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -867,7 +854,7 @@ dependencies = [
  "bitflags 2.5.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1372,21 +1359,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1399,12 +1377,6 @@ dependencies = [
  "quote",
  "syn 2.0.66",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2586,7 +2558,6 @@ dependencies = [
  "gifski",
  "henx",
  "imgref",
- "mouse_position",
  "objc",
  "opener",
  "os_info",
@@ -2605,7 +2576,6 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
- "tauri-runtime-wry",
  "tauri-utils",
  "tempfile",
  "tokio",
@@ -2649,17 +2619,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mouse_position"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824feb0675ad2ffda7b1da534f394c5779fb39d123b5f376a221d50fad54b3c2"
-dependencies = [
- "core-graphics 0.22.3",
- "winapi",
- "x11-dl",
 ]
 
 [[package]]
@@ -4240,8 +4199,8 @@ checksum = "d09e57a5a6b300bf917329da0ff30a58737d83abb7b14f99a419c23e83007cb8"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "core-graphics 0.23.2",
- "foreign-types 0.5.0",
+ "core-graphics",
+ "foreign-types",
  "js-sys",
  "log",
  "objc2",
@@ -4423,7 +4382,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cocoa",
  "core-foundation",
- "core-graphics 0.23.2",
+ "core-graphics",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -5207,7 +5166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad8319cca93189ea9ab1b290de0595960529750b6b8b501a399ed1ec3775d60"
 dependencies = [
  "cocoa",
- "core-graphics 0.23.2",
+ "core-graphics",
  "crossbeam-channel",
  "dirs",
  "libappindicator",
@@ -6035,7 +5994,7 @@ dependencies = [
  "base64 0.22.1",
  "block",
  "cocoa",
- "core-graphics 0.23.2",
+ "core-graphics",
  "crossbeam-channel",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,6 +48,7 @@ anyhow = "1.0"
 tauri-runtime-wry = "2.0.0-beta.18"
 core-graphics-helmer-fork = "0.24.0"
 runtime = "0.0.0"
+mouse_position = "0.1.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.56", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,10 +45,8 @@ rand = "0.8.5"
 tempfile = "3.10.0"
 chrono = "0.4.33"
 anyhow = "1.0"
-tauri-runtime-wry = "2.0.0-beta.18"
 core-graphics-helmer-fork = "0.24.0"
 runtime = "0.0.0"
-mouse_position = "0.1.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.56", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,9 @@ rand = "0.8.5"
 tempfile = "3.10.0"
 chrono = "0.4.33"
 anyhow = "1.0"
+tauri-runtime-wry = "2.0.0-beta.18"
+core-graphics-helmer-fork = "0.24.0"
+runtime = "0.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.56", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ chrono = "0.4.33"
 anyhow = "1.0"
 core-graphics-helmer-fork = "0.24.0"
 runtime = "0.0.0"
+mouse_position = "0.1.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.56", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -4,14 +4,8 @@
 	"description": "Capabilities for all windows; Has support for at max 4 capture windows/displays.",
 	"windows": [
 		"editor",
-		"cropper-0",
-		"record-0",
-		"cropper-1",
-		"record-1",
-		"cropper-2",
-		"record-2",
-		"cropper-3",
-		"record-3",
+		"cropper",
+		"record",
 		"welcome"
 	],
 	"permissions": [

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -1,11 +1,17 @@
 {
 	"$schema": "../gen/schemas/desktop-schema.json",
 	"identifier": "desktop-capability",
-	"description": "Capabilities for all windows",
+	"description": "Capabilities for all windows; Has support for at max 4 capture windows/displays.",
 	"windows": [
 		"editor",
-		"cropper",
-		"record",
+		"cropper-0",
+		"record-0",
+		"cropper-1",
+		"record-1",
+		"cropper-2",
+		"record-2",
+		"cropper-3",
+		"record-3",
 		"welcome"
 	],
 	"permissions": [

--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -1,6 +1,8 @@
 use crate::AppState;
+use core_graphics_helmer_fork::display::CGDisplayBounds;
 use tauri::{
-    utils::WindowEffect, AppHandle, LogicalSize, Manager, WebviewUrl, WebviewWindowBuilder,
+    utils::WindowEffect, AppHandle, LogicalPosition, LogicalSize, Manager, WebviewUrl,
+    WebviewWindowBuilder,
 };
 use tauri_utils::{config::WindowEffectsConfig, WindowEffectState};
 
@@ -40,108 +42,208 @@ fn set_transparency_and_level(win: tauri::WebviewWindow, level: u32) {
     .ok();
 }
 
-fn create_record_button_win(app: &AppHandle) {
-    let primary_monitor = app.primary_monitor().unwrap().unwrap();
-    let scale_factor = primary_monitor.scale_factor();
-    let monitor_size: LogicalSize<f64> = primary_monitor.size().to_logical(scale_factor);
+fn create_record_button_win(app: &AppHandle, target: scap::Target, label: &str) {
+    match target {
+        scap::Target::Display(target) => {
+            let monitor_size: LogicalSize<f64> = {
+                let mode = target.raw_handle.display_mode().unwrap();
+                LogicalSize::<f64>::new(mode.width() as f64, mode.height() as f64)
+            };
 
-    const RECORD_BUTTON_WIDTH: f64 = 200.0;
-    const RECORD_BUTTON_HEIGHT: f64 = 48.0;
+            const RECORD_BUTTON_WIDTH: f64 = 200.0;
+            const RECORD_BUTTON_HEIGHT: f64 = 48.0;
 
-    let mut record_win =
-        WebviewWindowBuilder::new(app, "record", WebviewUrl::App("/record".into()))
-            .title("recorder window")
-            .inner_size(RECORD_BUTTON_WIDTH, RECORD_BUTTON_HEIGHT)
-            .position(
-                (monitor_size.width / 2.0) - (RECORD_BUTTON_WIDTH / 2.0),
-                monitor_size.height - 200.0,
-            )
-            .accept_first_mouse(true)
-            .skip_taskbar(true)
-            .shadow(true)
-            .always_on_top(true)
-            .decorations(false)
-            .resizable(false)
-            .visible(false)
-            .effects(WindowEffectsConfig {
-                #[cfg(target_os = "macos")]
-                effects: vec![WindowEffect::Popover],
-                #[cfg(target_os = "macos")]
-                state: Some(WindowEffectState::Active),
-                #[cfg(target_os = "macos")]
-                radius: Some(10.0),
-                #[cfg(target_os = "windows")]
-                effects: vec![WindowEffect::Mica],
-                ..WindowEffectsConfig::default()
-            });
+            let record_win =
+                WebviewWindowBuilder::new(app, label, WebviewUrl::App("/record".into()))
+                    .title(format!("recorder window {}", target.title.as_str()))
+                    .inner_size(RECORD_BUTTON_WIDTH, RECORD_BUTTON_HEIGHT)
+                    .position(
+                        (monitor_size.width / 2.0) - (RECORD_BUTTON_WIDTH / 2.0),
+                        monitor_size.height - 200.0,
+                    )
+                    .accept_first_mouse(true)
+                    .skip_taskbar(true)
+                    .shadow(true)
+                    .always_on_top(true)
+                    .decorations(false)
+                    .resizable(false)
+                    .visible(false)
+                    .effects(WindowEffectsConfig {
+                        #[cfg(target_os = "macos")]
+                        effects: vec![WindowEffect::Popover],
+                        #[cfg(target_os = "macos")]
+                        state: Some(WindowEffectState::Active),
+                        #[cfg(target_os = "macos")]
+                        radius: Some(10.0),
+                        #[cfg(target_os = "windows")]
+                        effects: vec![WindowEffect::Mica],
+                        ..WindowEffectsConfig::default()
+                    });
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        record_win = record_win.transparent(true);
+            #[cfg(not(target_os = "macos"))]
+            {
+                record_win = record_win.transparent(true);
+            }
+
+            let record_win = record_win
+                .build()
+                .expect("Failed to build record button window");
+
+            #[cfg(target_os = "macos")]
+            {
+                let position: LogicalPosition<f64> = unsafe {
+                    let bounds = CGDisplayBounds(target.raw_handle.id);
+                    LogicalPosition::<f64>::new(
+                        bounds.origin.x + (monitor_size.width / 2.0) - (RECORD_BUTTON_WIDTH / 2.0),
+                        bounds.origin.y + monitor_size.height - 200.0,
+                    )
+                };
+                record_win.set_position(position).unwrap();
+                record_win.center().unwrap();
+            }
+
+            record_win
+                .to_owned()
+                .set_visible_on_all_workspaces(true)
+                .expect("Couldn't set visible on all workspaces");
+            // #[cfg(target_os = "windows")]
+            // hide_using_window_affinity(record_win.hwnd().unwrap());
+
+            #[cfg(target_os = "macos")]
+            set_transparency_and_level(record_win, 26);
+        }
+        scap::Target::Window(_) => {}
     }
-
-    let record_win = record_win
-        .build()
-        .expect("Failed to build record button window");
-
-    record_win
-        .to_owned()
-        .set_visible_on_all_workspaces(true)
-        .expect("Couldn't set visible on all workspaces");
-
-    // #[cfg(target_os = "windows")]
-    // hide_using_window_affinity(record_win.hwnd().unwrap());
-
-    #[cfg(target_os = "macos")]
-    set_transparency_and_level(record_win, 26);
 }
 
-fn create_cropper_win(app: &AppHandle) {
-    //  get size of primary monitor
-    let primary_monitor = app.primary_monitor().unwrap().unwrap();
-    let scale_factor = primary_monitor.scale_factor();
-    let monitor_size = primary_monitor.size().to_logical(scale_factor);
+fn create_cropper_win(app: &AppHandle, target: scap::Target, label: &str) {
+    match target {
+        scap::Target::Display(target) => {
+            // This piece of code can be used from scap if these methods are made public.
+            // It is repeated in create_button method (and not purposefully extracted into a method)
+            // as this can also be removed after/if we reuse this from scap.
+            let scale_factor = {
+                #[cfg(target_os = "macos")]
+                {
+                    let mode = target.raw_handle.display_mode().unwrap();
+                    (mode.pixel_width() / mode.width()) as f64
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let primary_monitor = app.primary_monitor().unwrap().unwrap();
+                    primary_monitor.scale_factor();
+                    primary_monitor.size().to_logical(scale_factor);
+                }
+            };
+            let monitor_size: LogicalSize<f64> = {
+                #[cfg(target_os = "macos")]
+                {
+                    let mode = target.raw_handle.display_mode().unwrap();
+                    LogicalSize::<f64>::new(
+                        mode.width() as f64 * scale_factor,
+                        mode.height() as f64 * scale_factor,
+                    )
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    let primary_monitor = app.primary_monitor().unwrap().unwrap();
 
-    // create cropper window
-    let mut cropper_win =
-        WebviewWindowBuilder::new(app, "cropper", WebviewUrl::App("/cropper".into()))
-            .title("cropper window")
-            .inner_size(monitor_size.width, monitor_size.height)
-            .accept_first_mouse(true)
-            .skip_taskbar(true)
-            .position(0.0, 0.0)
-            .always_on_top(true)
-            .decorations(false)
-            .resizable(false)
-            .visible(false)
-            .shadow(false)
-            .focused(false);
+                    primary_monitor.size().to_logical(scale_factor);
+                }
+            };
 
-    // set transparent only on windows and linux
-    #[cfg(not(target_os = "macos"))]
-    {
-        cropper_win = cropper_win.transparent(true);
+            // create cropper window
+            let cropper_win =
+                WebviewWindowBuilder::new(app, label, WebviewUrl::App("/cropper".into()))
+                    .title(format!("cropper window {}", target.title.as_str()))
+                    .inner_size(monitor_size.width, monitor_size.height)
+                    .accept_first_mouse(true)
+                    .skip_taskbar(true)
+                    .position(0.0, 0.0)
+                    .always_on_top(true)
+                    .decorations(false)
+                    .resizable(false)
+                    .visible(false)
+                    .shadow(false)
+                    .focused(false);
+
+            // set transparent only on windows and linux
+            #[cfg(not(target_os = "macos"))]
+            {
+                cropper_win = cropper_win.transparent(true);
+            }
+
+            let cropper_win = cropper_win.build().expect("Failed to open cropper");
+            cropper_win.set_visible_on_all_workspaces(true).unwrap();
+
+            // This is required for non-primary monitors - at least on mac
+            // Since multi-displays is currently not implemented for other
+            // platforms, this won't be required.
+            #[cfg(target_os = "macos")]
+            {
+                let position: LogicalPosition<f64> = unsafe {
+                    let bounds = CGDisplayBounds(target.raw_handle.id);
+                    LogicalPosition::<f64>::new(
+                        bounds.origin.x * scale_factor,
+                        bounds.origin.y * scale_factor,
+                    )
+                };
+                cropper_win.set_position(position).unwrap();
+                cropper_win.center().unwrap();
+            }
+            // #[cfg(target_os = "windows")]
+            // hide_using_window_affinity(cropper_win.hwnd().unwrap());
+
+            #[cfg(target_os = "macos")]
+            set_transparency_and_level(cropper_win, 25);
+        }
+        scap::Target::Window(_) => {}
     }
-
-    let cropper_win = cropper_win.build().expect("Failed to open cropper");
-    cropper_win.set_visible_on_all_workspaces(true).unwrap();
-
-    // #[cfg(target_os = "windows")]
-    // hide_using_window_affinity(cropper_win.hwnd().unwrap());
-
-    #[cfg(target_os = "macos")]
-    set_transparency_and_level(cropper_win, 25);
+    //  get size of primary monitor
 }
 
 pub fn init_cropper(app: &AppHandle) {
-    create_record_button_win(app);
-    create_cropper_win(app);
+    // TODO: Remove dependency on static labels and hence fixed
+    // number of windows/displays by re-using labels if possible.
+    //
+    // More Context:
+    //
+    // The labels need to be unique for all windows and we create
+    // different "record" and "capture" windows for all the
+    // displays/windows.
+    // These labels are statically declared in capabilities.json file
+    // and at max 4 displays are supported at the moment(hard-coded)
+    // till we figure out destroying windows and also removing labels
+    // with that
+    //
+    // In short: Creating 2 tauri windows with same labels fails and
+    // labels need declaration in "windows" property of tauri
+    // capabilities.json file.
+
+    let state = app.state::<AppState>();
+    state.targets.iter().enumerate().for_each(|(i, target)| {
+        create_record_button_win(app, target.to_owned(), format!("record-{}", i).as_str());
+        create_cropper_win(app, target.to_owned(), format!("cropper-{}", i).as_str());
+    });
 }
 
 pub fn toggle_cropper(app: &AppHandle) {
+    let state = app.state::<AppState>();
+
+    let curr_ind = match state.current_target_ind.try_lock() {
+        Ok(data) => data,
+        Err(_) => {
+            eprintln!("[toggle_cropper]: Could not get lock on current target index!");
+            return;
+        }
+    };
+    let record_win_label = format!("record-{}", curr_ind.clone());
+    let cropper_win_label = format!("cropper-{}", curr_ind.clone());
+    drop(curr_ind);
+
     if let (Some(cropper_win), Some(record_win)) = (
-        app.get_webview_window("cropper"),
-        app.get_webview_window("record"),
+        app.get_webview_window(cropper_win_label.as_str()),
+        app.get_webview_window(record_win_label.as_str()),
     ) {
         match cropper_win.is_visible().unwrap() || record_win.is_visible().unwrap() {
             true => {
@@ -166,9 +268,15 @@ pub fn toggle_cropper(app: &AppHandle) {
 
 #[tauri::command]
 pub async fn hide_cropper(app: AppHandle) {
+    let state = app.state::<AppState>();
+    let curr_ind = state.current_target_ind.lock().await;
+    let record_win_label = format!("record-{}", curr_ind.clone());
+    let cropper_win_label = format!("cropper-{}", curr_ind.clone());
+    drop(curr_ind);
+
     if let (Some(cropper_win), Some(record_win)) = (
-        app.get_webview_window("cropper"),
-        app.get_webview_window("record"),
+        app.get_webview_window(cropper_win_label.as_str()),
+        app.get_webview_window(record_win_label.as_str()),
     ) {
         record_win.hide().unwrap();
         cropper_win.hide().unwrap();
@@ -178,9 +286,12 @@ pub async fn hide_cropper(app: AppHandle) {
 
 #[tauri::command]
 pub async fn update_crop_area(app: AppHandle, area: Vec<u32>) {
-    println!("area: {:?}", area);
+    let state = app.state::<AppState>();
+    let curr_ind = state.current_target_ind.lock().await;
+    let record_win_label = format!("record-{}", curr_ind.to_owned());
+    drop(curr_ind);
 
-    if let Some(record_window) = app.get_webview_window("record") {
+    if let Some(record_window) = app.get_webview_window(record_win_label.as_str()) {
         record_window
             .emit("updated-crop-area", area.clone())
             .expect("couldn't pass crop area to record_window");

--- a/src-tauri/src/cropper/mod.rs
+++ b/src-tauri/src/cropper/mod.rs
@@ -1,8 +1,9 @@
 use crate::AppState;
-use core_graphics_helmer_fork::display::CGDisplayBounds;
+use core_graphics_helmer_fork::display::{self, CGDisplayBounds};
+use mouse_position::mouse_position::Mouse;
 use tauri::{
-    utils::WindowEffect, AppHandle, LogicalPosition, LogicalSize, Manager, WebviewUrl,
-    WebviewWindowBuilder,
+    utils::WindowEffect, App, AppHandle, LogicalPosition, LogicalSize, Manager, Monitor,
+    PhysicalSize, Size, WebviewUrl, WebviewWindow, WebviewWindowBuilder,
 };
 use tauri_utils::{config::WindowEffectsConfig, WindowEffectState};
 
@@ -42,208 +43,204 @@ fn set_transparency_and_level(win: tauri::WebviewWindow, level: u32) {
     .ok();
 }
 
-fn create_record_button_win(app: &AppHandle, target: scap::Target, label: &str) {
-    match target {
-        scap::Target::Display(target) => {
-            let monitor_size: LogicalSize<f64> = {
-                let mode = target.raw_handle.display_mode().unwrap();
-                LogicalSize::<f64>::new(mode.width() as f64, mode.height() as f64)
-            };
-
-            const RECORD_BUTTON_WIDTH: f64 = 200.0;
-            const RECORD_BUTTON_HEIGHT: f64 = 48.0;
-
-            let record_win =
-                WebviewWindowBuilder::new(app, label, WebviewUrl::App("/record".into()))
-                    .title(format!("recorder window {}", target.title.as_str()))
-                    .inner_size(RECORD_BUTTON_WIDTH, RECORD_BUTTON_HEIGHT)
-                    .position(
-                        (monitor_size.width / 2.0) - (RECORD_BUTTON_WIDTH / 2.0),
-                        monitor_size.height - 200.0,
-                    )
-                    .accept_first_mouse(true)
-                    .skip_taskbar(true)
-                    .shadow(true)
-                    .always_on_top(true)
-                    .decorations(false)
-                    .resizable(false)
-                    .visible(false)
-                    .effects(WindowEffectsConfig {
-                        #[cfg(target_os = "macos")]
-                        effects: vec![WindowEffect::Popover],
-                        #[cfg(target_os = "macos")]
-                        state: Some(WindowEffectState::Active),
-                        #[cfg(target_os = "macos")]
-                        radius: Some(10.0),
-                        #[cfg(target_os = "windows")]
-                        effects: vec![WindowEffect::Mica],
-                        ..WindowEffectsConfig::default()
-                    });
-
-            #[cfg(not(target_os = "macos"))]
-            {
-                record_win = record_win.transparent(true);
-            }
-
-            let record_win = record_win
-                .build()
-                .expect("Failed to build record button window");
-
-            #[cfg(target_os = "macos")]
-            {
-                let position: LogicalPosition<f64> = unsafe {
-                    let bounds = CGDisplayBounds(target.raw_handle.id);
-                    LogicalPosition::<f64>::new(
-                        bounds.origin.x + (monitor_size.width / 2.0) - (RECORD_BUTTON_WIDTH / 2.0),
-                        bounds.origin.y + monitor_size.height - 200.0,
-                    )
+fn tune_record_size_position(app: &AppHandle, target: &scap::Target) {
+    let win_maybe = app.get_webview_window("record");
+    if let Some(win) = win_maybe {
+        const RECORD_BUTTON_WIDTH: f64 = 200.0;
+        const RECORD_BUTTON_HEIGHT: f64 = 48.0;
+        match target {
+            scap::Target::Display(display) => {
+                let monitor_size: LogicalSize<f64> = {
+                    let mode = display.raw_handle.display_mode().unwrap();
+                    LogicalSize::<f64>::new(mode.width() as f64, mode.height() as f64)
                 };
-                record_win.set_position(position).unwrap();
-                record_win.center().unwrap();
+
+                #[cfg(target_os = "macos")]
+                {
+                    let position: LogicalPosition<f64> = unsafe {
+                        let bounds = CGDisplayBounds(display.raw_handle.id);
+                        LogicalPosition::<f64>::new(
+                            bounds.origin.x + (monitor_size.width / 2.0)
+                                - (RECORD_BUTTON_WIDTH / 2.0),
+                            bounds.origin.y + monitor_size.height - 200.0,
+                        )
+                    };
+                    win.set_position(position).unwrap();
+                    win.center().unwrap();
+                }
+                win.set_size(LogicalSize::new(RECORD_BUTTON_WIDTH, RECORD_BUTTON_HEIGHT))
+                    .unwrap();
             }
-
-            record_win
-                .to_owned()
-                .set_visible_on_all_workspaces(true)
-                .expect("Couldn't set visible on all workspaces");
-            // #[cfg(target_os = "windows")]
-            // hide_using_window_affinity(record_win.hwnd().unwrap());
-
-            #[cfg(target_os = "macos")]
-            set_transparency_and_level(record_win, 26);
+            scap::Target::Window(_) => {}
         }
-        scap::Target::Window(_) => {}
     }
 }
 
-fn create_cropper_win(app: &AppHandle, target: scap::Target, label: &str) {
-    match target {
-        scap::Target::Display(target) => {
-            // This piece of code can be used from scap if these methods are made public.
-            // It is repeated in create_button method (and not purposefully extracted into a method)
-            // as this can also be removed after/if we reuse this from scap.
-            let scale_factor = {
-                #[cfg(target_os = "macos")]
-                {
-                    let mode = target.raw_handle.display_mode().unwrap();
-                    (mode.pixel_width() / mode.width()) as f64
-                }
-                #[cfg(not(target_os = "macos"))]
-                {
-                    let primary_monitor = app.primary_monitor().unwrap().unwrap();
-                    primary_monitor.scale_factor();
-                    primary_monitor.size().to_logical(scale_factor);
-                }
-            };
-            let monitor_size: LogicalSize<f64> = {
-                #[cfg(target_os = "macos")]
-                {
-                    let mode = target.raw_handle.display_mode().unwrap();
-                    LogicalSize::<f64>::new(
-                        mode.width() as f64 * scale_factor,
-                        mode.height() as f64 * scale_factor,
-                    )
-                }
-                #[cfg(not(target_os = "macos"))]
-                {
-                    let primary_monitor = app.primary_monitor().unwrap().unwrap();
-
-                    primary_monitor.size().to_logical(scale_factor);
-                }
-            };
-
-            // create cropper window
-            let cropper_win =
-                WebviewWindowBuilder::new(app, label, WebviewUrl::App("/cropper".into()))
-                    .title(format!("cropper window {}", target.title.as_str()))
-                    .inner_size(monitor_size.width, monitor_size.height)
-                    .accept_first_mouse(true)
-                    .skip_taskbar(true)
-                    .position(0.0, 0.0)
-                    .always_on_top(true)
-                    .decorations(false)
-                    .resizable(false)
-                    .visible(false)
-                    .shadow(false)
-                    .focused(false);
-
-            // set transparent only on windows and linux
-            #[cfg(not(target_os = "macos"))]
-            {
-                cropper_win = cropper_win.transparent(true);
-            }
-
-            let cropper_win = cropper_win.build().expect("Failed to open cropper");
-            cropper_win.set_visible_on_all_workspaces(true).unwrap();
-
-            // This is required for non-primary monitors - at least on mac
-            // Since multi-displays is currently not implemented for other
-            // platforms, this won't be required.
-            #[cfg(target_os = "macos")]
-            {
-                let position: LogicalPosition<f64> = unsafe {
-                    let bounds = CGDisplayBounds(target.raw_handle.id);
-                    LogicalPosition::<f64>::new(
-                        bounds.origin.x * scale_factor,
-                        bounds.origin.y * scale_factor,
-                    )
+fn tune_cropper_size_position(app_handle: &AppHandle, target: &scap::Target) {
+    let win_maybe = app_handle.get_webview_window("cropper");
+    if let Some(win) = win_maybe {
+        match target {
+            scap::Target::Display(display) => {
+                let scale_factor = {
+                    #[cfg(target_os = "macos")]
+                    {
+                        let mode = display.raw_handle.display_mode().unwrap();
+                        (mode.pixel_width() / mode.width()) as f64
+                    }
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        let primary_monitor = app.primary_monitor().unwrap().unwrap();
+                        primary_monitor.scale_factor();
+                        primary_monitor.size().to_logical(scale_factor);
+                    }
                 };
-                cropper_win.set_position(position).unwrap();
-                cropper_win.center().unwrap();
-            }
-            // #[cfg(target_os = "windows")]
-            // hide_using_window_affinity(cropper_win.hwnd().unwrap());
+                let monitor_size: LogicalSize<f64> = {
+                    #[cfg(target_os = "macos")]
+                    {
+                        let mode = display.raw_handle.display_mode().unwrap();
+                        LogicalSize::<f64>::new(
+                            mode.width() as f64 * scale_factor,
+                            mode.height() as f64 * scale_factor,
+                        )
+                    }
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        let primary_monitor = app.primary_monitor().unwrap().unwrap();
 
-            #[cfg(target_os = "macos")]
-            set_transparency_and_level(cropper_win, 25);
+                        primary_monitor.size().to_logical(scale_factor);
+                    }
+                };
+                // This is required for non-primary monitors - at least on mac
+                // Since multi-displays is currently not implemented for other
+                // platforms, this won't be required.
+                #[cfg(target_os = "macos")]
+                {
+                    let position: LogicalPosition<f64> = unsafe {
+                        let bounds = CGDisplayBounds(display.raw_handle.id);
+                        LogicalPosition::<f64>::new(
+                            bounds.origin.x * scale_factor,
+                            bounds.origin.y * scale_factor,
+                        )
+                    };
+                    win.set_position(position).unwrap();
+                    win.center().unwrap();
+                }
+
+                win.set_size(LogicalSize::new(monitor_size.width, monitor_size.height))
+                    .unwrap();
+            }
+
+            scap::Target::Window(_) => {}
         }
-        scap::Target::Window(_) => {}
     }
+}
+
+fn create_record_button_win(app: &AppHandle, label: &str) {
+    let record_win = WebviewWindowBuilder::new(app, label, WebviewUrl::App("/record".into()))
+        .title(format!("recorder window {}", "record"))
+        .accept_first_mouse(true)
+        .skip_taskbar(true)
+        .shadow(true)
+        .always_on_top(true)
+        .decorations(false)
+        .resizable(false)
+        .visible(false)
+        .effects(WindowEffectsConfig {
+            #[cfg(target_os = "macos")]
+            effects: vec![WindowEffect::Popover],
+            #[cfg(target_os = "macos")]
+            state: Some(WindowEffectState::Active),
+            #[cfg(target_os = "macos")]
+            radius: Some(10.0),
+            #[cfg(target_os = "windows")]
+            effects: vec![WindowEffect::Mica],
+            ..WindowEffectsConfig::default()
+        });
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        record_win = record_win.transparent(true);
+    }
+
+    let record_win = record_win
+        .build()
+        .expect("Failed to build record button window");
+
+    record_win
+        .to_owned()
+        .set_visible_on_all_workspaces(true)
+        .expect("Couldn't set visible on all workspaces");
+    // #[cfg(target_os = "windows")]
+    // hide_using_window_affinity(record_win.hwnd().unwrap());
+
+    #[cfg(target_os = "macos")]
+    set_transparency_and_level(record_win, 26);
+}
+
+fn create_cropper_win(app: &AppHandle, label: &str) {
+    // This piece of code can be used from scap if these methods are made public.
+    // It is repeated in create_button method (and not purposefully extracted into a method)
+    // as this can also be removed after/if we reuse this from scap.
+
+    // create cropper window
+    let cropper_win = WebviewWindowBuilder::new(app, label, WebviewUrl::App("/cropper".into()))
+        .title(format!("cropper window {}", "cropper"))
+        .accept_first_mouse(true)
+        .skip_taskbar(true)
+        .position(0.0, 0.0)
+        .always_on_top(true)
+        .decorations(false)
+        .resizable(false)
+        .visible(false)
+        .shadow(false)
+        .focused(false);
+
+    // set transparent only on windows and linux
+    #[cfg(not(target_os = "macos"))]
+    {
+        cropper_win = cropper_win.transparent(true);
+    }
+
+    let cropper_win = cropper_win.build().expect("Failed to open cropper");
+    cropper_win.set_visible_on_all_workspaces(true).unwrap();
+
+    // #[cfg(target_os = "windows")]
+    // hide_using_window_affinity(cropper_win.hwnd().unwrap());
+
+    #[cfg(target_os = "macos")]
+    set_transparency_and_level(cropper_win, 25);
     //  get size of primary monitor
 }
 
 pub fn init_cropper(app: &AppHandle) {
-    // TODO: Remove dependency on static labels and hence fixed
-    // number of windows/displays by re-using labels if possible.
-    //
-    // More Context:
-    //
-    // The labels need to be unique for all windows and we create
-    // different "record" and "capture" windows for all the
-    // displays/windows.
-    // These labels are statically declared in capabilities.json file
-    // and at max 4 displays are supported at the moment(hard-coded)
-    // till we figure out destroying windows and also removing labels
-    // with that
-    //
-    // In short: Creating 2 tauri windows with same labels fails and
-    // labels need declaration in "windows" property of tauri
-    // capabilities.json file.
-
-    let state = app.state::<AppState>();
-    state.targets.iter().enumerate().for_each(|(i, target)| {
-        create_record_button_win(app, target.to_owned(), format!("record-{}", i).as_str());
-        create_cropper_win(app, target.to_owned(), format!("cropper-{}", i).as_str());
-    });
+    create_record_button_win(app, "record");
+    create_cropper_win(app, "cropper");
 }
 
 pub fn toggle_cropper(app: &AppHandle) {
-    let state = app.state::<AppState>();
-
-    let curr_ind = match state.current_target_ind.try_lock() {
-        Ok(data) => data,
-        Err(_) => {
-            eprintln!("[toggle_cropper]: Could not get lock on current target index!");
+    let position = Mouse::get_mouse_position();
+    match position {
+        Mouse::Position { x, y } => {
+            if let Some(monitor) = app.monitor_from_point(x as f64, y as f64).unwrap() {
+                if let Some(target) = get_target_from_monitor(app, monitor) {
+                    tune_record_size_position(app, &target);
+                    tune_cropper_size_position(app, &target);
+                } else {
+                    eprintln!("Could not deduce display target from tuari monitor");
+                    return;
+                }
+            } else {
+                println!("Could not get tauri monitor from mouse point");
+            }
+        }
+        Mouse::Error => {
+            eprintln!("Error getting mouse position");
             return;
         }
-    };
-    let record_win_label = format!("record-{}", curr_ind.clone());
-    let cropper_win_label = format!("cropper-{}", curr_ind.clone());
-    drop(curr_ind);
-
+    }
     if let (Some(cropper_win), Some(record_win)) = (
-        app.get_webview_window(cropper_win_label.as_str()),
-        app.get_webview_window(record_win_label.as_str()),
+        app.get_webview_window("cropper"),
+        app.get_webview_window("record"),
     ) {
         match cropper_win.is_visible().unwrap() || record_win.is_visible().unwrap() {
             true => {
@@ -268,15 +265,9 @@ pub fn toggle_cropper(app: &AppHandle) {
 
 #[tauri::command]
 pub async fn hide_cropper(app: AppHandle) {
-    let state = app.state::<AppState>();
-    let curr_ind = state.current_target_ind.lock().await;
-    let record_win_label = format!("record-{}", curr_ind.clone());
-    let cropper_win_label = format!("cropper-{}", curr_ind.clone());
-    drop(curr_ind);
-
     if let (Some(cropper_win), Some(record_win)) = (
-        app.get_webview_window(cropper_win_label.as_str()),
-        app.get_webview_window(record_win_label.as_str()),
+        app.get_webview_window("cropper"),
+        app.get_webview_window("record"),
     ) {
         record_win.hide().unwrap();
         cropper_win.hide().unwrap();
@@ -286,12 +277,7 @@ pub async fn hide_cropper(app: AppHandle) {
 
 #[tauri::command]
 pub async fn update_crop_area(app: AppHandle, area: Vec<u32>) {
-    let state = app.state::<AppState>();
-    let curr_ind = state.current_target_ind.lock().await;
-    let record_win_label = format!("record-{}", curr_ind.to_owned());
-    drop(curr_ind);
-
-    if let Some(record_window) = app.get_webview_window(record_win_label.as_str()) {
+    if let Some(record_window) = app.get_webview_window("record") {
         record_window
             .emit("updated-crop-area", area.clone())
             .expect("couldn't pass crop area to record_window");
@@ -303,4 +289,42 @@ pub async fn update_crop_area(app: AppHandle, area: Vec<u32>) {
     let mut cropped_area = state.cropped_area.lock().await;
     *cropped_area = area.clone();
     drop(cropped_area);
+}
+
+fn get_target_from_monitor(app: &AppHandle, monitor: Monitor) -> Option<scap::Target> {
+    let pos = monitor.position();
+    let state = app.state::<AppState>();
+    let mut ret_target = None;
+    for target in state.targets.iter() {
+        match target {
+            scap::Target::Display(display) => {
+                // No other fancy way to infer target from monitor other than physical position
+                // which remains same across all monitors and display targets.
+                unsafe {
+                    let bounds = CGDisplayBounds(display.raw_handle.id);
+                    if bounds.origin.x == (pos.x as f64) && bounds.origin.y == (pos.y as f64) {
+                        update_target(app, target.clone());
+                        ret_target = Some(target.clone());
+                    }
+                };
+            }
+            scap::Target::Window(_) => {}
+        }
+    }
+    ret_target
+}
+
+fn update_target(app: &AppHandle, target: scap::Target) {
+    let state = app.state::<AppState>();
+
+    let mut data = match state.current_target.try_lock() {
+        Ok(data) => data,
+        Err(_) => {
+            eprintln!("[update_target]: Could not get lock on current target index!");
+            return;
+        }
+    };
+
+    *data = Some(target);
+    drop(data);
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,10 +24,7 @@ pub struct AppState {
     cropped_area: Mutex<Vec<u32>>,
     preview_path: Mutex<Option<PathBuf>>,
     targets: Vec<Target>,
-    // index is taken since this will be used for window labels (static as of now)
-    // across all plaforms, id can be different than incrementing numbers or change
-    // due to underlying implementation.
-    current_target_ind: Mutex<i8>,
+    current_target: Mutex<Option<scap::Target>>,
 
     #[cfg(target_os = "macos")]
     shown_permission_prompt: Mutex<bool>,
@@ -42,7 +39,7 @@ impl Default for AppState {
             preview_path: Mutex::new(None),
             targets: scap::get_all_targets(),
             // Negative value means signifies no current target.
-            current_target_ind: Mutex::new(-1),
+            current_target: Mutex::new(Option::None),
 
             #[cfg(target_os = "macos")]
             shown_permission_prompt: Mutex::new(false),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,7 +6,7 @@ mod editor;
 mod recorder;
 mod tray;
 
-use scap::{capturer::Capturer, frame::Frame};
+use scap::{capturer::Capturer, frame::Frame, Target};
 use std::path::PathBuf;
 use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_global_shortcut::ShortcutState;
@@ -23,6 +23,11 @@ pub struct AppState {
     recorder: Mutex<Option<Capturer>>,
     cropped_area: Mutex<Vec<u32>>,
     preview_path: Mutex<Option<PathBuf>>,
+    targets: Vec<Target>,
+    // index is taken since this will be used for window labels (static as of now)
+    // across all plaforms, id can be different than incrementing numbers or change
+    // due to underlying implementation.
+    current_target_ind: Mutex<i8>,
 
     #[cfg(target_os = "macos")]
     shown_permission_prompt: Mutex<bool>,
@@ -35,6 +40,9 @@ impl Default for AppState {
             recorder: Mutex::new(None),
             cropped_area: Mutex::new(Vec::new()),
             preview_path: Mutex::new(None),
+            targets: scap::get_all_targets(),
+            // Negative value means signifies no current target.
+            current_target_ind: Mutex::new(-1),
 
             #[cfg(target_os = "macos")]
             shown_permission_prompt: Mutex::new(false),

--- a/src-tauri/src/recorder/mod.rs
+++ b/src-tauri/src/recorder/mod.rs
@@ -23,14 +23,6 @@ pub async fn start_recording(app_handle: AppHandle) {
     }
 
     let curr_target = state.current_target.lock().await;
-    let target = {
-        if let Some(target) = curr_target.clone() {
-            target
-        } else {
-            eprintln!("Failed to get target for recording!");
-            return;
-        }
-    };
     let cropper_win = app_handle.get_webview_window("cropper").unwrap();
 
     // Disable cursor events on cropper window
@@ -38,7 +30,7 @@ pub async fn start_recording(app_handle: AppHandle) {
 
     // Start capturing frames
     let app_handle_clone = app_handle.clone();
-    start_frame_capture(app_handle_clone, &target).await;
+    start_frame_capture(app_handle_clone, &curr_target.clone()).await;
     drop(curr_target);
 
     let state = app_handle.state::<AppState>();

--- a/src-tauri/src/recorder/utils.rs
+++ b/src-tauri/src/recorder/utils.rs
@@ -1,42 +1,56 @@
 use crate::AppState;
+use core_graphics_helmer_fork::display::CGDisplayBounds;
 use rand::Rng;
 use scap::{
-    capturer::{Point, Area, Size, Capturer, Options, Resolution},
+    capturer::{Area, Capturer, Options, Point, Resolution, Size},
     frame::FrameType,
 };
 use tauri::{AppHandle, Manager};
 
 pub const FRAME_TYPE: FrameType = FrameType::BGRAFrame;
 
-pub async fn start_frame_capture(app_handle: AppHandle) {
-    let state = app_handle.state::<AppState>();
+pub async fn start_frame_capture(app_handle: AppHandle, target: &scap::Target) {
+    let state: tauri::State<AppState> = app_handle.state::<AppState>();
 
     // area is of the form [x1, y1, x2, y2]
     // we need it of the form [x1, y1, x2-x1, y2-y1]
-    let area = state.cropped_area.lock().await.clone();
-    let crop_area = vec![
-        area[0] as f64,
-        area[1] as f64,
-        area[2] as f64 - area[0] as f64,
-        area[3] as f64 - area[1] as f64,
-    ];
+    let cropped_area = state.cropped_area.lock().await;
+    let abs_area = cropped_area.clone();
+    drop(cropped_area);
+    let area = {
+        if let scap::Target::Display(display) = target {
+            let position = unsafe {
+                let bounds = CGDisplayBounds(display.id);
+                vec![bounds.origin.x, bounds.origin.y]
+            };
+            vec![
+                abs_area[0] as f64 + position[0],
+                abs_area[1] as f64 + position[1],
+                abs_area[2] as f64 + position[0],
+                abs_area[3] as f64 + position[1],
+            ]
+        } else {
+            vec![
+                abs_area[0] as f64,
+                abs_area[1] as f64,
+                abs_area[2] as f64,
+                abs_area[3] as f64,
+            ]
+        }
+    };
 
+    let crop_area = vec![area[0], area[1], area[2] - area[0], area[3] - area[1]];
     let record_cursor = crate::tray::get_tray_setting(&app_handle, "record_cursor".into());
-
     // Initialize scap
     let options = Options {
         fps: 60,
-        targets: Vec::new(),
+        target: Some(target.clone()),
         show_cursor: record_cursor,
         show_highlight: false,
         excluded_targets: None,
-        excluded_windows: Some(vec![
-            "recorder window".to_string(),
-            "cropper window".to_string(),
-        ]),
         output_type: FRAME_TYPE,
         output_resolution: Resolution::_1080p, // TODO: doesn't respect aspect ratio yet
-        source_rect: Some(Area {
+        crop_area: Some(Area {
             origin: Point {
                 x: crop_area[0],
                 y: crop_area[1],

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -1,15 +1,15 @@
 mod updater;
 
-use crate::{cropper::toggle_cropper, AppState};
+use crate::cropper::toggle_cropper;
 use opener::open;
 use tauri::{
     image::Image,
     menu::{
-        AboutMetadataBuilder, CheckMenuItemBuilder, IsMenuItem, MenuBuilder, MenuItemBuilder,
-        PredefinedMenuItem, Submenu,
+        AboutMetadataBuilder, CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder,
+        PredefinedMenuItem,
     },
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, EventLoopMessage, Manager,
+    AppHandle,
 };
 
 use tauri_plugin_store::StoreBuilder;
@@ -40,7 +40,6 @@ pub fn build(app: &AppHandle) {
                 .checked(get_tray_setting(app, "record_cursor".to_string()))
                 .build(app)
                 .expect(""),
-            &get_targets_submenu(app),
             &CheckMenuItemBuilder::with_id("share_usage_data", "Share Usage Data")
                 .checked(get_tray_setting(app, "share_usage_data".to_string()))
                 .build(app)
@@ -81,33 +80,7 @@ pub fn build(app: &AppHandle) {
             }
             "record_cursor" => update_tray_setting(app, "record_cursor".to_string()),
             "share_usage_data" => update_tray_setting(app, "share_usage_data".to_string()),
-            _label => {
-                let state = app.state::<AppState>();
-                let mut i: i8 = 0;
-                for target in state.targets.iter() {
-                    let id: String = {
-                        if let scap::Target::Display(target) = target {
-                            format!("target_{}", target.id).clone()
-                        } else {
-                            String::new()
-                        }
-                    };
-                    if _label == id.as_str() {
-                        update_target(app, i);
-                    } else {
-                        if let Some(an_item) = tray_menu.get("targets_submenu") {
-                            if let Some(submenu) = an_item.as_submenu() {
-                                if let Some(menu_item) = submenu.get(id.as_str()) {
-                                    if let Some(check_menu_item) = menu_item.as_check_menuitem() {
-                                        check_menu_item.set_checked(false).unwrap();
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    i += 1;
-                }
-            }
+            _ => (),
         })
         .on_tray_icon_event(|tray, event| {
             if let TrayIconEvent::Click {
@@ -169,83 +142,6 @@ fn update_tray_setting(app: &AppHandle, key: String) {
     let updated_value = get_tray_setting(app, key.clone());
 
     println!("{}: {}", key, updated_value);
-}
-
-fn get_targets_submenu(
-    app: &AppHandle,
-) -> tauri::menu::Submenu<tauri_runtime_wry::Wry<EventLoopMessage>> {
-    let mut enabled = true;
-    #[cfg(not(target_os = "macos"))]
-    {
-        enabled = false;
-    }
-
-    let mut check_menu_items = vec![];
-
-    let state = app.state::<AppState>();
-    for (i, target) in state.targets.iter().enumerate() {
-        // Default display for recording
-        // - kept as first one
-        // - usually the primary display
-        if i == 0 {
-            update_target(app, i as i8);
-        }
-        match target {
-            scap::Target::Display(target) => {
-                let menu_item = CheckMenuItemBuilder::with_id(
-                    format!("target_{}", target.id),
-                    target.title.as_str(),
-                )
-                .checked(i == 0)
-                .build(app)
-                .expect("");
-                check_menu_items.push(menu_item);
-            }
-            scap::Target::Window(_) => {
-                // yet to be supported.
-            }
-        }
-    }
-
-    let boxed_items: Vec<Box<dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>>> =
-        check_menu_items
-            .into_iter()
-            .map(|item| {
-                Box::new(item) as Box<dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>>
-            })
-            .collect();
-
-    let unboxed_targets: &[&dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>] =
-        &(*boxed_items)
-            .iter()
-            .map(|item| &(**item) as &dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>)
-            .collect::<Vec<_>>()[..];
-
-    let submenu: Submenu<tauri_runtime_wry::Wry<EventLoopMessage>> = Submenu::with_id_and_items(
-        app,
-        "targets_submenu",
-        "Target Display",
-        enabled,
-        unboxed_targets,
-    )
-    .expect("");
-    submenu
-}
-
-fn update_target(app: &AppHandle, target_index: i8) -> bool {
-    let state = app.state::<AppState>();
-
-    let mut data = match state.current_target_ind.try_lock() {
-        Ok(data) => data,
-        Err(_) => {
-            eprintln!("[update_target]: Could not get lock on current target index!");
-            return false;
-        }
-    };
-
-    *data = target_index;
-    drop(data);
-    true
 }
 
 #[tauri::command]

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -1,16 +1,17 @@
 mod updater;
 
-use crate::cropper::toggle_cropper;
+use crate::{cropper::toggle_cropper, AppState};
 use opener::open;
 use tauri::{
     image::Image,
     menu::{
-        AboutMetadataBuilder, CheckMenuItemBuilder, MenuBuilder, MenuItemBuilder,
-        PredefinedMenuItem,
+        AboutMetadataBuilder, CheckMenuItemBuilder, IsMenuItem, MenuBuilder, MenuItemBuilder,
+        PredefinedMenuItem, Submenu,
     },
-    tray::{ClickType, TrayIconBuilder},
-    AppHandle,
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    AppHandle, EventLoopMessage, Manager,
 };
+
 use tauri_plugin_store::StoreBuilder;
 
 pub use updater::check_for_update;
@@ -39,6 +40,7 @@ pub fn build(app: &AppHandle) {
                 .checked(get_tray_setting(app, "record_cursor".to_string()))
                 .build(app)
                 .expect(""),
+            &get_targets_submenu(app),
             &CheckMenuItemBuilder::with_id("share_usage_data", "Share Usage Data")
                 .checked(get_tray_setting(app, "share_usage_data".to_string()))
                 .build(app)
@@ -79,12 +81,42 @@ pub fn build(app: &AppHandle) {
             }
             "record_cursor" => update_tray_setting(app, "record_cursor".to_string()),
             "share_usage_data" => update_tray_setting(app, "share_usage_data".to_string()),
-            _ => (),
+            _label => {
+                let state = app.state::<AppState>();
+                let mut i: i8 = 0;
+                for target in state.targets.iter() {
+                    let id: String = {
+                        if let scap::Target::Display(target) = target {
+                            format!("target_{}", target.id).clone()
+                        } else {
+                            String::new()
+                        }
+                    };
+                    if _label == id.as_str() {
+                        update_target(app, i);
+                    } else {
+                        if let Some(an_item) = tray_menu.get("targets_submenu") {
+                            if let Some(submenu) = an_item.as_submenu() {
+                                if let Some(menu_item) = submenu.get(id.as_str()) {
+                                    if let Some(check_menu_item) = menu_item.as_check_menuitem() {
+                                        check_menu_item.set_checked(false).unwrap();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    i += 1;
+                }
+            }
         })
         .on_tray_icon_event(|tray, event| {
-            if event.click_type == ClickType::Left {
-                // TODO: if not already recording
-                let app = tray.app_handle();
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Down,
+                ..
+            } = event
+            {
+                let app: &AppHandle = tray.app_handle();
                 toggle_cropper(app);
             }
         });
@@ -137,6 +169,83 @@ fn update_tray_setting(app: &AppHandle, key: String) {
     let updated_value = get_tray_setting(app, key.clone());
 
     println!("{}: {}", key, updated_value);
+}
+
+fn get_targets_submenu(
+    app: &AppHandle,
+) -> tauri::menu::Submenu<tauri_runtime_wry::Wry<EventLoopMessage>> {
+    let mut enabled = true;
+    #[cfg(not(target_os = "macos"))]
+    {
+        enabled = false;
+    }
+
+    let mut check_menu_items = vec![];
+
+    let state = app.state::<AppState>();
+    for (i, target) in state.targets.iter().enumerate() {
+        // Default display for recording
+        // - kept as first one
+        // - usually the primary display
+        if i == 0 {
+            update_target(app, i as i8);
+        }
+        match target {
+            scap::Target::Display(target) => {
+                let menu_item = CheckMenuItemBuilder::with_id(
+                    format!("target_{}", target.id),
+                    target.title.as_str(),
+                )
+                .checked(i == 0)
+                .build(app)
+                .expect("");
+                check_menu_items.push(menu_item);
+            }
+            scap::Target::Window(_) => {
+                // yet to be supported.
+            }
+        }
+    }
+
+    let boxed_items: Vec<Box<dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>>> =
+        check_menu_items
+            .into_iter()
+            .map(|item| {
+                Box::new(item) as Box<dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>>
+            })
+            .collect();
+
+    let unboxed_targets: &[&dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>] =
+        &(*boxed_items)
+            .iter()
+            .map(|item| &(**item) as &dyn IsMenuItem<tauri_runtime_wry::Wry<EventLoopMessage>>)
+            .collect::<Vec<_>>()[..];
+
+    let submenu: Submenu<tauri_runtime_wry::Wry<EventLoopMessage>> = Submenu::with_id_and_items(
+        app,
+        "targets_submenu",
+        "Target Display",
+        enabled,
+        unboxed_targets,
+    )
+    .expect("");
+    submenu
+}
+
+fn update_target(app: &AppHandle, target_index: i8) -> bool {
+    let state = app.state::<AppState>();
+
+    let mut data = match state.current_target_ind.try_lock() {
+        Ok(data) => data,
+        Err(_) => {
+            eprintln!("[update_target]: Could not get lock on current target index!");
+            return false;
+        }
+    };
+
+    *data = target_index;
+    drop(data);
+    true
 }
 
 #[tauri::command]


### PR DESCRIPTION
This PR contributes  to https://github.com/helmerapp/micro/issues/59 with following changes: 

* Added a submenu to system tray menu to choose display targets ; disabled for non-Mac platform !
 * By default chooses the first target returned by scap and sets that (usually primary display)
 * Hard-coded (4) number of displays supported as of now.
	* Why this is so ? : Window labels need to be unique and pre-declared constants in tauri capabilities.json file (to the best of my knowledge) and cannot be re-assigned. So, these are hardcoded to 4 till a better solution is found. :(

<img width="570" alt="image" src="https://github.com/helmerapp/micro/assets/40715071/bc467afd-7365-4b89-bec0-5d268d60e20c">


